### PR TITLE
docs(release): restore 2.0.0 breaking change notes

### DIFF
--- a/.github/release-notes/2.0.0.md
+++ b/.github/release-notes/2.0.0.md
@@ -1,0 +1,18 @@
+## ⚠ BREAKING CHANGES
+
+- **Local Kubernetes development now uses Kind instead of K3s.** The Docker Compose-managed K3s environment was replaced by a reproducible three-node Kind cluster.
+- `examples/docker-compose.yaml` and the `examples/config/` directory were removed.
+- `make k8s-setup` now creates the cluster from `config/kind-config.yaml` and generates `config/kubeconfig.yaml`.
+- Scripts, IDE settings, and automation that reference `examples/config/kubeconfig.yaml` must use `config/kubeconfig.yaml`.
+- Existing K3s development clusters must be removed and recreated with Kind.
+
+## Migration
+
+1. From a `1.0.0` checkout, run `make k8s-teardown` to remove the previous K3s/Docker Compose environment.
+2. Update the repository and run `make bootstrap` to install the pinned Kind CLI when required.
+3. Run `make k8s-setup` to create the Kind cluster and generate `config/kubeconfig.yaml`.
+4. Replace references to `examples/config/kubeconfig.yaml` with `config/kubeconfig.yaml` in local scripts and tool configuration.
+
+## Code Refactoring
+
+- Migrate local Kubernetes development from K3s to Kind ([d88deb7](https://github.com/sentenz/template-k8s/commit/d88deb72dc9b49e4be69466958e11fdbb73e93f4)).

--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -1,0 +1,15 @@
+# Release Notes
+
+Semantic-Release derives version changes and release notes from the final commit message on `main`.
+
+For a breaking change, the final commit must use both the `!` marker and an explicit `BREAKING CHANGE:` footer. The marker determines the major version; the footer provides the migration information rendered in the GitHub release and `CHANGELOG.md`.
+
+```text
+refactor!: replace the local Kubernetes runtime
+
+BREAKING CHANGE: Local development now uses Kind instead of K3s. Remove the existing K3s environment, run `make k8s-setup`, and update kubeconfig references from `examples/config/kubeconfig.yaml` to `config/kubeconfig.yaml`.
+```
+
+When squash-merging a pull request, verify that the squash commit body preserves the footer. A header-only `!` can indicate a major release without retaining enough information for actionable release notes in every parser and preset combination.
+
+Version-specific correction sources in this directory are synchronized to their existing GitHub releases by the corresponding workflow under `.github/workflows/`.

--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -12,4 +12,6 @@ BREAKING CHANGE: Local development now uses Kind instead of K3s. Remove the exis
 
 When squash-merging a pull request, verify that the squash commit body preserves the footer. A header-only `!` can indicate a major release without retaining enough information for actionable release notes in every parser and preset combination.
 
+The Semantic-Release workflow pins `conventional-changelog-conventionalcommits@9.3.1`. Keep this preset aligned with the version supported by `@semantic-release/release-notes-generator`; do not adopt a new preset major implicitly through a floating range because its parser or writer contract may change independently.
+
 Version-specific correction sources in this directory are synchronized to their existing GitHub releases by the corresponding workflow under `.github/workflows/`.

--- a/.github/workflows/release-notes-correction.yml
+++ b/.github/workflows/release-notes-correction.yml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release Notes Correction
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/release-notes/2.0.0.md
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-release-notes:
+    name: Update 2.0.0 Release Notes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: 2.0.0
+          RELEASE_NOTES_FILE: .github/release-notes/2.0.0.md
+        run: |
+          set -euo pipefail
+
+          gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null
+          gh release edit "${RELEASE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${RELEASE_TAG}" \
+            --notes-file "${RELEASE_NOTES_FILE}"

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           semantic-version: "latest"
+          extra-plugins: |
+            @semantic-release/changelog@^6
+            @semantic-release/git@^10
+            conventional-changelog-conventionalcommits@9.3.1
 
       - name: Run SBOM Generation (CycloneDX)
         if: steps.release.outputs.new-release-published == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [2.0.0](https://github.com/sentenz/template-k8s/compare/1.0.0...2.0.0) (2026-07-19)
 
+### ⚠ BREAKING CHANGES
+
+* **local development:** replace the Docker Compose-managed K3s environment with a reproducible three-node Kind cluster. The `examples/docker-compose.yaml` file and the `examples/config/` directory were removed. `make k8s-setup` now creates the cluster with `config/kind-config.yaml` and writes its generated kubeconfig to `config/kubeconfig.yaml`. Scripts, IDE settings, and automation that reference `examples/config/kubeconfig.yaml` must use the new path, and existing K3s development clusters must be removed and recreated with Kind.
+
+### Code Refactoring
+
+* **local development:** migrate local Kubernetes development from K3s to Kind ([d88deb7](https://github.com/sentenz/template-k8s/commit/d88deb72dc9b49e4be69466958e11fdbb73e93f4))
+
+### Migration
+
+1. From a `1.0.0` checkout, run `make k8s-teardown` to remove the previous K3s/Docker Compose environment.
+2. Update the repository and run `make bootstrap` to install the pinned Kind CLI when required.
+3. Run `make k8s-setup` to create the Kind cluster and generate `config/kubeconfig.yaml`.
+4. Replace references to `examples/config/kubeconfig.yaml` with `config/kubeconfig.yaml` in local scripts and tool configuration.
+
 # 1.0.0 (2026-01-05)
 
 


### PR DESCRIPTION
## Summary

Restore the missing breaking-change documentation for release `2.0.0` and correct the release-note dependency configuration without creating an artificial `3.0.0` release.

## Root cause

Commit `d88deb72dc9b49e4be69466958e11fdbb73e93f4` used the breaking header `refactor!:`. Semantic-Release correctly selected the major version `2.0.0`, but the generated release notes contained only the release heading.

The release action installed `conventional-changelog-conventionalcommits@^10`, while the release-notes generator integration is aligned with the 9.x parser/writer contract. Version 10 introduced breaking preset and writer changes, so version analysis succeeded while note rendering produced no content. In addition, the squash commit omitted an explicit `BREAKING CHANGE:` footer, so it did not preserve the detailed migration narrative required for useful release notes.

## Changes

- pin `conventional-changelog-conventionalcommits@9.3.1` in the Semantic-Release workflow
- add the missing `BREAKING CHANGES`, code-refactoring, and migration sections to `CHANGELOG.md`
- add `.github/release-notes/2.0.0.md` as the authoritative corrected GitHub release body
- add an idempotent workflow that updates the existing `2.0.0` GitHub release when the correction source reaches `main`
- document that breaking commits must contain both the `!` marker and an explicit `BREAKING CHANGE:` footer, including for squash merges
- document that the Conventional Commits preset must remain compatible with the release-notes generator

## Release behavior

The PR title uses the non-releasing `docs` type. After merge, the release-note correction workflow edits the existing `2.0.0` release; Semantic-Release should not publish a new version for this correction.

## Validation

- verified the branch modifies only release configuration, release documentation, and the changelog
- parsed both modified workflow files as YAML
- validated the `gh release edit` shell block with `bash -n`
- verified all migration paths and commands against the K3s-to-Kind change in commit `d88deb7`
- Conftest, Regal, Semgrep, and Trivy checks pass
