### PR TITLE
chore(release): repair 2.0.0 release notes

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -31,7 +31,11 @@ jobs:
         uses: sentenz/actions/semantic-release@bceed480720a7bc304e974cd655ebe42ac41d5e2 # 1.1.9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          semantic-version: "latest"
+          semantic-version: "25.0.3"
+          extra-plugins: |
+            @semantic-release/changelog@^6
+            @semantic-release/git@^10
+            conventional-changelog-conventionalcommits@9.3.1
 
       - name: Run SBOM Generation (CycloneDX)
         if: steps.release.outputs.new-release-published == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [2.0.0](https://github.com/sentenz/template-k8s/compare/1.0.0...2.0.0) (2026-07-19)
 
+### ⚠ BREAKING CHANGES
+
+* local Kubernetes development now uses Kind instead of the Docker Compose-based K3s environment
+* the previous K3s Docker Compose definition and the obsolete `examples/config/` paths have been removed
+* local cluster configuration now resides in `config/kind-config.yaml`, and the generated kubeconfig is written to `config/kubeconfig.yaml`
+* use `make k8s-setup` and `make k8s-teardown` for the local cluster lifecycle
+
+### Code Refactoring
+
+* migrate local Kubernetes development from K3s to Kind ([#36](https://github.com/sentenz/template-k8s/issues/36)) ([d88deb7](https://github.com/sentenz/template-k8s/commit/d88deb72dc9b49e4be69466958e11fdbb73e93f4))
+
 # 1.0.0 (2026-01-05)
 
 


### PR DESCRIPTION
## Summary

- document the breaking K3s-to-Kind migration in the `2.0.0` changelog section
- pin semantic-release to `25.0.3`
- override the composite action defaults with `conventional-changelog-conventionalcommits@9.3.1`
- retain the existing `2.0.0` tag and release commit without rewriting published history

## Root cause

The breaking-change marker in `refactor!:` was analyzed correctly and produced the major `2.0.0` version. Release-note rendering was empty because the workflow installed `conventional-changelog-conventionalcommits@^10`, while the selected release-notes-generator line uses the version 9 writer interface and tests against `9.3.1`.

## Impact

The existing `2.0.0` changelog gains explicit migration guidance. Future releases use a deterministic semantic-release and conventional-commits preset combination, preventing version-only changelog sections.

## Validation

- branch is based directly on release commit `f18c38989914f968c91c998f6946c88e9683a642`
- 2 commits ahead of `main`, 0 behind
- 2 files changed: 16 additions and 1 deletion
- workflow YAML was re-read from the branch after modification
- published tag `2.0.0` was not moved or recreated
