### PR TITLE
fix: resolve Dependency-Track chart v2 deployment values

### DIFF
--- a/manifests/base/dependency-track/values.yaml
+++ b/manifests/base/dependency-track/values.yaml
@@ -9,7 +9,7 @@ database:
 secretManagement:
   database:
     kek:
-      value: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+      value: "h1lrkPlxxIe9K92pUQkV4O+gn4NMP1E9pN4p94zC5IE="
 
 apiServer:
   service:

--- a/manifests/base/dependency-track/values.yaml
+++ b/manifests/base/dependency-track/values.yaml
@@ -1,14 +1,20 @@
 ---
-common:
+database:
+  jdbcUrl: "jdbc:postgresql://postgresql.postgresql.svc.cluster.local:5432/dtrack"
+  username: "dtrack"
+  password: "dtrack"
+
+# Development-only fixture KEK. Replace with an externally managed Secret for
+# any persistent or non-local environment.
+secretManagement:
   database:
-    jdbcUrl: "jdbc:postgresql://postgresql.postgresql.svc.cluster.local:5432/dtrack"
-    username: "dtrack"
-    password: "dtrack"
+    kek:
+      value: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
 apiServer:
   service:
     type: ClusterIP
-  metrics:
+  serviceMonitor:
     enabled: false
   extraEnv: []
 

--- a/manifests/overlays/dev/dependency-track/patch-dependency-track-ingress.yaml
+++ b/manifests/overlays/dev/dependency-track/patch-dependency-track-ingress.yaml
@@ -22,13 +22,6 @@ spec:
                 name: dependency-track-api-server
                 port:
                   name: web
-          - path: /health
-            pathType: Prefix
-            backend:
-              service:
-                name: dependency-track-api-server
-                port:
-                  name: web
           - path: /
             pathType: Prefix
             backend:


### PR DESCRIPTION
## Summary

- migrate the Dependency-Track values file to the chart 2.x schema
- replace the removed `apiServer.metrics` setting with `apiServer.serviceMonitor`
- add an explicitly development-only fixture KEK so the local stack can start with database-backed secret management
- remove the obsolete external `/health` ingress route, since chart 2.x serves health checks on the pod-only management port

## Root cause

The repository was upgraded to Dependency-Track chart `2.0.0-rc.3`, but its custom values retained chart 1.x keys. Helm schema validation therefore rejected `common` and `apiServer.metrics`, causing Kustomize accumulation to fail and leaving `kubectl apply` with no objects.

## Impact

The development overlay should render against chart `2.0.0-rc.3` without the reported values-schema errors. The fixture KEK is intentionally public and suitable only for this disposable local development configuration; persistent or non-local deployments must replace it with an externally managed Secret.

## Validation

Not executed in the automation environment because Helm and Kustomize binaries are unavailable.

Run locally:

```bash
make k8s-render-dependency-track K8S_ENV=dev
make k8s-deploy-dependency-track K8S_ENV=dev
```
