### PR TITLE
feat(kind): publish custom kind CLI container image

### DIFF
--- a/.github/workflows/kind-container.yml
+++ b/.github/workflows/kind-container.yml
@@ -12,9 +12,6 @@ on:
       - main
     tags:
       - kind-v*
-    paths:
-      - container/kind/**
-      - .github/workflows/kind-container.yml
   workflow_dispatch:
     inputs:
       kind_version:
@@ -54,6 +51,8 @@ jobs:
     name: Build, smoke test, and scan
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    outputs:
+      kind_version: ${{ steps.version.outputs.kind_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -141,6 +140,9 @@ jobs:
       startsWith(github.ref, 'refs/tags/kind-v') ||
       (github.event_name == 'workflow_dispatch' && inputs.publish)
     needs: validate
+    concurrency:
+      group: kind-container-publish-${{ needs.validate.outputs.kind_version }}
+      cancel-in-progress: false
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     permissions:
@@ -151,27 +153,6 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-
-      - name: Resolve kind version
-        id: version
-        shell: bash
-        env:
-          DISPATCH_KIND_VERSION: ${{ inputs.kind_version }}
-        run: |
-          set -euo pipefail
-
-          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == kind-v* ]]; then
-            kind_version="${GITHUB_REF_NAME#kind-}"
-          else
-            kind_version="${DISPATCH_KIND_VERSION}"
-          fi
-
-          if ! [[ "${kind_version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
-            echo "Invalid kind version: ${kind_version}" >&2
-            exit 1
-          fi
-
-          echo "kind_version=${kind_version}" >> "${GITHUB_OUTPUT}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
@@ -191,7 +172,7 @@ jobs:
       - name: Protect immutable version tag
         shell: bash
         env:
-          KIND_VERSION: ${{ steps.version.outputs.kind_version }}
+          KIND_VERSION: ${{ needs.validate.outputs.kind_version }}
         run: |
           set -euo pipefail
           version_image="${IMAGE_NAME}:${KIND_VERSION}"
@@ -206,14 +187,14 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ steps.version.outputs.kind_version }}
+            type=raw,value=${{ needs.validate.outputs.kind_version }}
             type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && inputs.update_latest }}
           labels: |
             org.opencontainers.image.title=kind CLI
             org.opencontainers.image.description=Containerized client environment for the Kubernetes kind CLI
             org.opencontainers.image.url=https://github.com/sentenz/template-k8s
             org.opencontainers.image.source=https://github.com/sentenz/template-k8s
-            org.opencontainers.image.version=${{ steps.version.outputs.kind_version }}
+            org.opencontainers.image.version=${{ needs.validate.outputs.kind_version }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=Apache-2.0
 
@@ -230,7 +211,7 @@ jobs:
           provenance: mode=max
           sbom: true
           build-args: |
-            KIND_VERSION=${{ steps.version.outputs.kind_version }}
+            KIND_VERSION=${{ needs.validate.outputs.kind_version }}
 
       - name: Inspect published manifest
         shell: bash
@@ -275,13 +256,14 @@ jobs:
           provenance: false
           sbom: false
           build-args: |
-            KIND_VERSION=${{ inputs.kind_version }}
+            KIND_VERSION=${{ needs.validate.outputs.kind_version }}
 
       - name: Create cluster
         shell: bash
         run: |
           set -euo pipefail
           docker run --rm \
+            --network host \
             --volume /var/run/docker.sock:/var/run/docker.sock \
             --volume "${GITHUB_WORKSPACE}:/workspace" \
             --workdir /workspace \
@@ -307,6 +289,7 @@ jobs:
         shell: bash
         run: |
           docker run --rm \
+            --network host \
             --volume /var/run/docker.sock:/var/run/docker.sock \
             local/kind:cluster-test \
             delete cluster \

--- a/.github/workflows/kind-container.yml
+++ b/.github/workflows/kind-container.yml
@@ -1,0 +1,313 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Kind CLI Container
+
+on:
+  pull_request:
+    paths:
+      - container/kind/**
+      - .github/workflows/kind-container.yml
+  push:
+    branches:
+      - main
+    tags:
+      - kind-v*
+    paths:
+      - container/kind/**
+      - .github/workflows/kind-container.yml
+  workflow_dispatch:
+    inputs:
+      kind_version:
+        description: kind release version to build
+        required: true
+        default: v0.32.0
+        type: string
+      publish:
+        description: Publish the immutable version tag to GHCR
+        required: true
+        default: false
+        type: boolean
+      update_latest:
+        description: Also update the moving latest tag
+        required: true
+        default: false
+        type: boolean
+      run_cluster_test:
+        description: Create and delete a cluster using the host Docker socket
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: kind-container-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  DEFAULT_KIND_VERSION: v0.32.0
+  IMAGE_NAME: ghcr.io/sentenz/kind
+
+jobs:
+  validate:
+    name: Build, smoke test, and scan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Resolve kind version
+        id: version
+        shell: bash
+        env:
+          DISPATCH_KIND_VERSION: ${{ inputs.kind_version }}
+        run: |
+          set -euo pipefail
+
+          kind_version="${DEFAULT_KIND_VERSION}"
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == kind-v* ]]; then
+            kind_version="${GITHUB_REF_NAME#kind-}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            kind_version="${DISPATCH_KIND_VERSION}"
+          fi
+
+          if ! [[ "${kind_version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid kind version: ${kind_version}" >&2
+            exit 1
+          fi
+
+          echo "kind_version=${kind_version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        with:
+          platforms: amd64,arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Validate multi-platform build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: container/kind/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          outputs: type=cacheonly
+          build-args: |
+            KIND_VERSION=${{ steps.version.outputs.kind_version }}
+
+      - name: Build local smoke-test image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: container/kind/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: local/kind:${{ github.sha }}
+          provenance: false
+          sbom: false
+          build-args: |
+            KIND_VERSION=${{ steps.version.outputs.kind_version }}
+
+      - name: Smoke test kind version
+        shell: bash
+        env:
+          EXPECTED_KIND_VERSION: ${{ steps.version.outputs.kind_version }}
+          TEST_IMAGE: local/kind:${{ github.sha }}
+        run: |
+          set -euo pipefail
+          version_output="$(docker run --rm "${TEST_IMAGE}" version)"
+          printf '%s\n' "${version_output}"
+          grep -F -- "${EXPECTED_KIND_VERSION}" <<< "${version_output}"
+
+      - name: Scan local image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: local/kind:${{ github.sha }}
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: os
+          severity: CRITICAL
+
+  publish:
+    name: Publish multi-platform image
+    if: >-
+      startsWith(github.ref, 'refs/tags/kind-v') ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish)
+    needs: validate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Resolve kind version
+        id: version
+        shell: bash
+        env:
+          DISPATCH_KIND_VERSION: ${{ inputs.kind_version }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == kind-v* ]]; then
+            kind_version="${GITHUB_REF_NAME#kind-}"
+          else
+            kind_version="${DISPATCH_KIND_VERSION}"
+          fi
+
+          if ! [[ "${kind_version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid kind version: ${kind_version}" >&2
+            exit 1
+          fi
+
+          echo "kind_version=${kind_version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        with:
+          platforms: amd64,arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Protect immutable version tag
+        shell: bash
+        env:
+          KIND_VERSION: ${{ steps.version.outputs.kind_version }}
+        run: |
+          set -euo pipefail
+          version_image="${IMAGE_NAME}:${KIND_VERSION}"
+          if docker buildx imagetools inspect "${version_image}" >/dev/null 2>&1; then
+            echo "Refusing to overwrite existing image tag: ${version_image}" >&2
+            exit 1
+          fi
+
+      - name: Generate OCI metadata
+        id: metadata
+        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.kind_version }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && inputs.update_latest }}
+          labels: |
+            org.opencontainers.image.title=kind CLI
+            org.opencontainers.image.description=Containerized client environment for the Kubernetes kind CLI
+            org.opencontainers.image.url=https://github.com/sentenz/template-k8s
+            org.opencontainers.image.source=https://github.com/sentenz/template-k8s
+            org.opencontainers.image.version=${{ steps.version.outputs.kind_version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=Apache-2.0
+
+      - name: Build and publish image
+        id: build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: container/kind/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+          build-args: |
+            KIND_VERSION=${{ steps.version.outputs.kind_version }}
+
+      - name: Inspect published manifest
+        shell: bash
+        env:
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "${IMAGE_NAME}@${IMAGE_DIGEST}"
+
+      - name: Scan published image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: os
+          severity: CRITICAL
+
+  cluster-test:
+    name: Create cluster through CLI container
+    if: github.event_name == 'workflow_dispatch' && inputs.run_cluster_test
+    needs: validate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build local cluster-test image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: container/kind/Dockerfile
+          load: true
+          tags: local/kind:cluster-test
+          provenance: false
+          sbom: false
+          build-args: |
+            KIND_VERSION=${{ inputs.kind_version }}
+
+      - name: Create cluster
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --volume /var/run/docker.sock:/var/run/docker.sock \
+            --volume "${GITHUB_WORKSPACE}:/workspace" \
+            --workdir /workspace \
+            local/kind:cluster-test \
+            create cluster \
+            --name template-k8s-container-test \
+            --config config/kind-cluster.yaml \
+            --wait 5m
+
+      - name: Verify cluster nodes
+        shell: bash
+        run: |
+          set -euo pipefail
+          node_count="$({ docker ps --filter label=io.x-k8s.kind.cluster=template-k8s-container-test --format '{{.ID}}'; } | wc -l | tr -d ' ')"
+          if [[ "${node_count}" != "3" ]]; then
+            echo "Expected three kind nodes, found ${node_count}" >&2
+            docker ps --filter label=io.x-k8s.kind.cluster=template-k8s-container-test >&2
+            exit 1
+          fi
+
+      - name: Delete cluster
+        if: always()
+        shell: bash
+        run: |
+          docker run --rm \
+            --volume /var/run/docker.sock:/var/run/docker.sock \
+            local/kind:cluster-test \
+            delete cluster \
+            --name template-k8s-container-test

--- a/.github/workflows/kind-container.yml
+++ b/.github/workflows/kind-container.yml
@@ -12,20 +12,23 @@ on:
       - main
     tags:
       - kind-v*
+    paths:
+      - container/kind/**
+      - .github/workflows/kind-container.yml
   workflow_dispatch:
     inputs:
       kind_version:
-        description: kind release version to build
+        description: kind release version to build or promote
         required: true
         default: v0.32.0
         type: string
       publish:
-        description: Publish the immutable version tag to GHCR
+        description: Publish a new immutable version tag to GHCR
         required: true
         default: false
         type: boolean
       update_latest:
-        description: Also update the moving latest tag
+        description: Promote the selected immutable version to latest
         required: true
         default: false
         type: boolean
@@ -36,8 +39,8 @@ on:
         type: boolean
 
 concurrency:
-  group: kind-container-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: kind-container-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ inputs.kind_version || 'default' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -47,18 +50,13 @@ env:
   IMAGE_NAME: ghcr.io/sentenz/kind
 
 jobs:
-  validate:
-    name: Build, smoke test, and scan
+  prepare:
+    name: Resolve kind version
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 5
     outputs:
       kind_version: ${{ steps.version.outputs.kind_version }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          persist-credentials: false
-
       - name: Resolve kind version
         id: version
         shell: bash
@@ -81,73 +79,16 @@ jobs:
 
           echo "kind_version=${kind_version}" >> "${GITHUB_OUTPUT}"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-        with:
-          platforms: amd64,arm64
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-
-      - name: Validate multi-platform build
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: .
-          file: container/kind/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: false
-          outputs: type=cacheonly
-          build-args: |
-            KIND_VERSION=${{ steps.version.outputs.kind_version }}
-
-      - name: Build local smoke-test image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: .
-          file: container/kind/Dockerfile
-          platforms: linux/amd64
-          load: true
-          tags: local/kind:${{ github.sha }}
-          provenance: false
-          sbom: false
-          build-args: |
-            KIND_VERSION=${{ steps.version.outputs.kind_version }}
-
-      - name: Smoke test kind version
-        shell: bash
-        env:
-          EXPECTED_KIND_VERSION: ${{ steps.version.outputs.kind_version }}
-          TEST_IMAGE: local/kind:${{ github.sha }}
-        run: |
-          set -euo pipefail
-          version_output="$(docker run --rm "${TEST_IMAGE}" version)"
-          printf '%s\n' "${version_output}"
-          grep -F -- "${EXPECTED_KIND_VERSION}" <<< "${version_output}"
-
-      - name: Scan local image
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: local/kind:${{ github.sha }}
-          format: table
-          exit-code: "1"
-          ignore-unfixed: true
-          vuln-type: os
-          severity: CRITICAL
-
-  publish:
-    name: Publish multi-platform image
+  validate:
+    name: Build, smoke test, and scan
+    needs: prepare
     if: >-
-      startsWith(github.ref, 'refs/tags/kind-v') ||
-      (github.event_name == 'workflow_dispatch' && inputs.publish)
-    needs: validate
-    concurrency:
-      group: kind-container-publish-${{ needs.validate.outputs.kind_version }}
-      cancel-in-progress: false
+      github.event_name != 'workflow_dispatch' ||
+      inputs.publish ||
+      inputs.update_latest != true ||
+      inputs.run_cluster_test
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
-    permissions:
-      contents: read
-      packages: write
+    timeout-minutes: 35
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -162,6 +103,117 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      - name: Build local amd64 image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: container/kind/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: local/kind:${{ github.sha }}-amd64
+          provenance: false
+          sbom: false
+          build-args: |
+            KIND_VERSION=${{ needs.prepare.outputs.kind_version }}
+
+      - name: Build arm64 image archive
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: container/kind/Dockerfile
+          platforms: linux/arm64
+          outputs: type=docker,dest=${{ runner.temp }}/kind-arm64.tar
+          provenance: false
+          sbom: false
+          build-args: |
+            KIND_VERSION=${{ needs.prepare.outputs.kind_version }}
+
+      - name: Smoke test kind version
+        shell: bash
+        env:
+          EXPECTED_KIND_VERSION: ${{ needs.prepare.outputs.kind_version }}
+          TEST_IMAGE: local/kind:${{ github.sha }}-amd64
+        run: |
+          set -euo pipefail
+          version_output="$(docker run --rm "${TEST_IMAGE}" version)"
+          printf '%s\n' "${version_output}"
+          grep -F -- "${EXPECTED_KIND_VERSION}" <<< "${version_output}"
+
+      - name: Scan amd64 image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: local/kind:${{ github.sha }}-amd64
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          scanners: vuln
+          vuln-type: os,library
+          severity: CRITICAL
+
+      - name: Scan arm64 image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          input: ${{ runner.temp }}/kind-arm64.tar
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          scanners: vuln
+          vuln-type: os,library
+          severity: CRITICAL
+
+  release:
+    name: Publish or promote image
+    needs:
+      - prepare
+      - validate
+    if: >-
+      always() &&
+      needs.prepare.result == 'success' &&
+      (
+        (
+          startsWith(github.ref, 'refs/tags/kind-v') ||
+          (github.event_name == 'workflow_dispatch' && inputs.publish)
+        ) &&
+        needs.validate.result == 'success'
+        ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          inputs.update_latest &&
+          inputs.publish != true &&
+          (
+            needs.validate.result == 'success' ||
+            needs.validate.result == 'skipped'
+          )
+        )
+      )
+    concurrency:
+      group: kind-container-release-${{ needs.prepare.outputs.kind_version }}
+      cancel-in-progress: false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    env:
+      KIND_VERSION: ${{ needs.prepare.outputs.kind_version }}
+      PUBLISH_VERSION: ${{ startsWith(github.ref, 'refs/tags/kind-v') || inputs.publish }}
+      UPDATE_LATEST: ${{ github.event_name == 'workflow_dispatch' && inputs.update_latest }}
+    steps:
+      - name: Checkout
+        if: env.PUBLISH_VERSION == 'true'
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up QEMU
+        if: env.PUBLISH_VERSION == 'true'
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        with:
+          platforms: amd64,arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
       - name: Log in to GHCR
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
@@ -169,72 +221,136 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Protect immutable version tag
+      - name: Validate requested release operation
         shell: bash
-        env:
-          KIND_VERSION: ${{ needs.validate.outputs.kind_version }}
         run: |
           set -euo pipefail
+
           version_image="${IMAGE_NAME}:${KIND_VERSION}"
-          if docker buildx imagetools inspect "${version_image}" >/dev/null 2>&1; then
-            echo "Refusing to overwrite existing image tag: ${version_image}" >&2
-            exit 1
+          if [[ "${PUBLISH_VERSION}" == "true" ]]; then
+            if docker buildx imagetools inspect "${version_image}" >/dev/null 2>&1; then
+              echo "Refusing to overwrite existing image tag: ${version_image}" >&2
+              exit 1
+            fi
+          elif [[ "${UPDATE_LATEST}" == "true" ]]; then
+            if ! docker buildx imagetools inspect "${version_image}" >/dev/null 2>&1; then
+              echo "Cannot promote missing image tag: ${version_image}" >&2
+              exit 1
+            fi
           fi
 
       - name: Generate OCI metadata
+        if: env.PUBLISH_VERSION == 'true'
         id: metadata
         uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
         with:
           images: ${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=${{ needs.validate.outputs.kind_version }}
-            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && inputs.update_latest }}
           labels: |
             org.opencontainers.image.title=kind CLI
             org.opencontainers.image.description=Containerized client environment for the Kubernetes kind CLI
             org.opencontainers.image.url=https://github.com/sentenz/template-k8s
             org.opencontainers.image.source=https://github.com/sentenz/template-k8s
-            org.opencontainers.image.version=${{ needs.validate.outputs.kind_version }}
+            org.opencontainers.image.version=${{ needs.prepare.outputs.kind_version }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=Apache-2.0
 
-      - name: Build and publish image
-        id: build
+      - name: Build and push amd64 release candidate
+        if: env.PUBLISH_VERSION == 'true'
+        id: build_amd64
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: container/kind/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.metadata.outputs.tags }}
+          platforms: linux/amd64
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.metadata.outputs.labels }}
           provenance: mode=max
           sbom: true
           build-args: |
-            KIND_VERSION=${{ needs.validate.outputs.kind_version }}
+            KIND_VERSION=${{ needs.prepare.outputs.kind_version }}
 
-      - name: Inspect published manifest
-        shell: bash
-        env:
-          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
-        run: |
-          set -euo pipefail
-          docker buildx imagetools inspect "${IMAGE_NAME}@${IMAGE_DIGEST}"
-
-      - name: Scan published image
+      - name: Scan amd64 release candidate
+        if: env.PUBLISH_VERSION == 'true'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_PLATFORM: linux/amd64
         with:
-          image-ref: ${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          image-ref: ${{ env.IMAGE_NAME }}@${{ steps.build_amd64.outputs.digest }}
           format: table
           exit-code: "1"
           ignore-unfixed: true
-          vuln-type: os
+          scanners: vuln
+          vuln-type: os,library
           severity: CRITICAL
+
+      - name: Build and push arm64 release candidate
+        if: env.PUBLISH_VERSION == 'true'
+        id: build_arm64
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: container/kind/Dockerfile
+          platforms: linux/arm64
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          labels: ${{ steps.metadata.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+          build-args: |
+            KIND_VERSION=${{ needs.prepare.outputs.kind_version }}
+
+      - name: Scan arm64 release candidate
+        if: env.PUBLISH_VERSION == 'true'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_PLATFORM: linux/arm64
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}@${{ steps.build_arm64.outputs.digest }}
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          scanners: vuln
+          vuln-type: os,library
+          severity: CRITICAL
+
+      - name: Publish immutable version tag
+        if: env.PUBLISH_VERSION == 'true'
+        shell: bash
+        env:
+          AMD64_DIGEST: ${{ steps.build_amd64.outputs.digest }}
+          ARM64_DIGEST: ${{ steps.build_arm64.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          version_image="${IMAGE_NAME}:${KIND_VERSION}"
+          docker buildx imagetools create \
+            --tag "${version_image}" \
+            "${IMAGE_NAME}@${AMD64_DIGEST}" \
+            "${IMAGE_NAME}@${ARM64_DIGEST}"
+          docker buildx imagetools inspect "${version_image}"
+
+      - name: Promote immutable version to latest
+        if: env.UPDATE_LATEST == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version_image="${IMAGE_NAME}:${KIND_VERSION}"
+          latest_image="${IMAGE_NAME}:latest"
+          docker buildx imagetools inspect "${version_image}"
+          docker buildx imagetools create \
+            --tag "${latest_image}" \
+            "${version_image}"
+          docker buildx imagetools inspect "${latest_image}"
 
   cluster-test:
     name: Create cluster through CLI container
-    if: github.event_name == 'workflow_dispatch' && inputs.run_cluster_test
-    needs: validate
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.run_cluster_test &&
+      needs.validate.result == 'success'
+    needs:
+      - prepare
+      - validate
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
@@ -256,7 +372,7 @@ jobs:
           provenance: false
           sbom: false
           build-args: |
-            KIND_VERSION=${{ needs.validate.outputs.kind_version }}
+            KIND_VERSION=${{ needs.prepare.outputs.kind_version }}
 
       - name: Create cluster
         shell: bash

--- a/.github/workflows/kind-container.yml
+++ b/.github/workflows/kind-container.yml
@@ -48,6 +48,7 @@ permissions:
 env:
   DEFAULT_KIND_VERSION: v0.32.0
   IMAGE_NAME: ghcr.io/sentenz/kind
+  TRIVY_VERSION: v0.70.0
 
 jobs:
   prepare:
@@ -139,38 +140,56 @@ jobs:
           printf '%s\n' "${version_output}"
           grep -F -- "${EXPECTED_KIND_VERSION}" <<< "${version_output}"
 
-      - name: Set up Trivy
-        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514
-
-      - name: Scan amd64 image
+      - name: Export amd64 image archive
         shell: bash
         env:
           TEST_IMAGE: local/kind:${{ github.sha }}-amd64
         run: |
           set -euo pipefail
-          trivy image \
-            --format json \
-            --output trivy-amd64.json \
-            --exit-code 0 \
-            --ignore-unfixed \
-            --scanners vuln \
-            --pkg-types os,library \
-            --severity CRITICAL \
+          docker save \
+            --output "${RUNNER_TEMP}/kind-amd64.tar" \
             "${TEST_IMAGE}"
 
-      - name: Scan arm64 image
+      - name: Set up Trivy
+        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
+        with:
+          version: ${{ env.TRIVY_VERSION }}
+          cache: true
+
+      - name: Scan architecture archives
+        id: scan
         shell: bash
         run: |
           set -euo pipefail
-          trivy image \
-            --input "${RUNNER_TEMP}/kind-arm64.tar" \
-            --format json \
-            --output trivy-arm64.json \
-            --exit-code 0 \
-            --ignore-unfixed \
-            --scanners vuln \
-            --pkg-types os,library \
-            --severity CRITICAL
+
+          trivy --version
+          scanner_failed=0
+          for arch in amd64 arm64; do
+            archive="${RUNNER_TEMP}/kind-${arch}.tar"
+            report="trivy-${arch}.json"
+            log="trivy-${arch}.log"
+
+            set +e
+            trivy image \
+              --input "${archive}" \
+              --format json \
+              --output "${report}" \
+              --exit-code 0 \
+              --ignore-unfixed \
+              --scanners vuln \
+              --pkg-types os,library \
+              --severity CRITICAL \
+              2>&1 | tee "${log}"
+            status="${PIPESTATUS[0]}"
+            set -e
+
+            if (( status != 0 )); then
+              echo "::error title=Trivy ${arch} scan failed::Trivy exited with status ${status}"
+              scanner_failed=1
+            fi
+          done
+
+          echo "scanner_failed=${scanner_failed}" >> "${GITHUB_OUTPUT}"
 
       - name: Upload vulnerability reports
         if: always()
@@ -179,16 +198,30 @@ jobs:
           name: kind-vulnerability-reports-${{ github.sha }}
           path: |
             trivy-amd64.json
+            trivy-amd64.log
             trivy-arm64.json
-          if-no-files-found: error
+            trivy-arm64.log
+          if-no-files-found: warn
 
       - name: Enforce vulnerability policy
         shell: bash
+        env:
+          SCANNER_FAILED: ${{ steps.scan.outputs.scanner_failed }}
         run: |
           set -euo pipefail
 
+          if [[ "${SCANNER_FAILED}" != "0" ]]; then
+            echo "One or more Trivy scans failed before producing a valid report." >&2
+            exit 1
+          fi
+
           findings=0
           for report in trivy-amd64.json trivy-arm64.json; do
+            if [[ ! -s "${report}" ]]; then
+              echo "Missing vulnerability report: ${report}" >&2
+              exit 1
+            fi
+
             count="$(jq '[.Results[]?.Vulnerabilities[]?] | length' "${report}")"
             printf '%s: %s critical finding(s)\n' "${report}" "${count}"
             if (( count > 0 )); then
@@ -319,20 +352,6 @@ jobs:
           build-args: |
             KIND_VERSION=${{ needs.prepare.outputs.kind_version }}
 
-      - name: Scan amd64 release candidate
-        if: env.PUBLISH_VERSION == 'true'
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        env:
-          TRIVY_PLATFORM: linux/amd64
-        with:
-          image-ref: ${{ env.IMAGE_NAME }}@${{ steps.build_amd64.outputs.digest }}
-          format: table
-          exit-code: "1"
-          ignore-unfixed: true
-          scanners: vuln
-          vuln-type: os,library
-          severity: CRITICAL
-
       - name: Build and push arm64 release candidate
         if: env.PUBLISH_VERSION == 'true'
         id: build_arm64
@@ -348,19 +367,111 @@ jobs:
           build-args: |
             KIND_VERSION=${{ needs.prepare.outputs.kind_version }}
 
-      - name: Scan arm64 release candidate
+      - name: Set up Trivy
         if: env.PUBLISH_VERSION == 'true'
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        env:
-          TRIVY_PLATFORM: linux/arm64
+        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
         with:
-          image-ref: ${{ env.IMAGE_NAME }}@${{ steps.build_arm64.outputs.digest }}
-          format: table
-          exit-code: "1"
-          ignore-unfixed: true
-          scanners: vuln
-          vuln-type: os,library
-          severity: CRITICAL
+          version: ${{ env.TRIVY_VERSION }}
+          cache: true
+
+      - name: Scan release candidates
+        if: env.PUBLISH_VERSION == 'true'
+        id: release_scan
+        shell: bash
+        env:
+          AMD64_DIGEST: ${{ steps.build_amd64.outputs.digest }}
+          ARM64_DIGEST: ${{ steps.build_arm64.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          trivy --version
+          scanner_failed=0
+          for arch in amd64 arm64; do
+            if [[ "${arch}" == "amd64" ]]; then
+              digest="${AMD64_DIGEST}"
+            else
+              digest="${ARM64_DIGEST}"
+            fi
+
+            report="trivy-release-${arch}.json"
+            log="trivy-release-${arch}.log"
+
+            set +e
+            trivy image \
+              --platform "linux/${arch}" \
+              --format json \
+              --output "${report}" \
+              --exit-code 0 \
+              --ignore-unfixed \
+              --scanners vuln \
+              --pkg-types os,library \
+              --severity CRITICAL \
+              "${IMAGE_NAME}@${digest}" \
+              2>&1 | tee "${log}"
+            status="${PIPESTATUS[0]}"
+            set -e
+
+            if (( status != 0 )); then
+              echo "::error title=Trivy ${arch} release scan failed::Trivy exited with status ${status}"
+              scanner_failed=1
+            fi
+          done
+
+          echo "scanner_failed=${scanner_failed}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload release vulnerability reports
+        if: env.PUBLISH_VERSION == 'true' && always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kind-release-vulnerability-reports-${{ needs.prepare.outputs.kind_version }}
+          path: |
+            trivy-release-amd64.json
+            trivy-release-amd64.log
+            trivy-release-arm64.json
+            trivy-release-arm64.log
+          if-no-files-found: warn
+
+      - name: Enforce release vulnerability policy
+        if: env.PUBLISH_VERSION == 'true'
+        shell: bash
+        env:
+          SCANNER_FAILED: ${{ steps.release_scan.outputs.scanner_failed }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${SCANNER_FAILED}" != "0" ]]; then
+            echo "One or more release-candidate scans failed before producing a valid report." >&2
+            exit 1
+          fi
+
+          findings=0
+          for report in trivy-release-amd64.json trivy-release-arm64.json; do
+            if [[ ! -s "${report}" ]]; then
+              echo "Missing vulnerability report: ${report}" >&2
+              exit 1
+            fi
+
+            count="$(jq '[.Results[]?.Vulnerabilities[]?] | length' "${report}")"
+            printf '%s: %s critical finding(s)\n' "${report}" "${count}"
+            if (( count > 0 )); then
+              jq -r '
+                .Results[]? as $result
+                | $result.Vulnerabilities[]?
+                | [
+                    $result.Target,
+                    .PkgName,
+                    .InstalledVersion,
+                    (.FixedVersion // "unfixed"),
+                    .VulnerabilityID,
+                    .Title
+                  ]
+                | @tsv
+              ' "${report}"
+              findings=1
+            fi
+          done
+
+          exit "${findings}"
 
       - name: Publish immutable version tag
         if: env.PUBLISH_VERSION == 'true'

--- a/.github/workflows/kind-container.yml
+++ b/.github/workflows/kind-container.yml
@@ -139,29 +139,38 @@ jobs:
           printf '%s\n' "${version_output}"
           grep -F -- "${EXPECTED_KIND_VERSION}" <<< "${version_output}"
 
+      - name: Set up Trivy
+        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514
+
       - name: Scan amd64 image
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: local/kind:${{ github.sha }}-amd64
-          format: json
-          output: trivy-amd64.json
-          exit-code: "0"
-          ignore-unfixed: true
-          scanners: vuln
-          vuln-type: os,library
-          severity: CRITICAL
+        shell: bash
+        env:
+          TEST_IMAGE: local/kind:${{ github.sha }}-amd64
+        run: |
+          set -euo pipefail
+          trivy image \
+            --format json \
+            --output trivy-amd64.json \
+            --exit-code 0 \
+            --ignore-unfixed \
+            --scanners vuln \
+            --pkg-types os,library \
+            --severity CRITICAL \
+            "${TEST_IMAGE}"
 
       - name: Scan arm64 image
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          input: ${{ runner.temp }}/kind-arm64.tar
-          format: json
-          output: trivy-arm64.json
-          exit-code: "0"
-          ignore-unfixed: true
-          scanners: vuln
-          vuln-type: os,library
-          severity: CRITICAL
+        shell: bash
+        run: |
+          set -euo pipefail
+          trivy image \
+            --input "${RUNNER_TEMP}/kind-arm64.tar" \
+            --format json \
+            --output trivy-arm64.json \
+            --exit-code 0 \
+            --ignore-unfixed \
+            --scanners vuln \
+            --pkg-types os,library \
+            --severity CRITICAL
 
       - name: Upload vulnerability reports
         if: always()

--- a/.github/workflows/kind-container.yml
+++ b/.github/workflows/kind-container.yml
@@ -143,8 +143,9 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: local/kind:${{ github.sha }}-amd64
-          format: table
-          exit-code: "1"
+          format: json
+          output: trivy-amd64.json
+          exit-code: "0"
           ignore-unfixed: true
           scanners: vuln
           vuln-type: os,library
@@ -154,12 +155,52 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           input: ${{ runner.temp }}/kind-arm64.tar
-          format: table
-          exit-code: "1"
+          format: json
+          output: trivy-arm64.json
+          exit-code: "0"
           ignore-unfixed: true
           scanners: vuln
           vuln-type: os,library
           severity: CRITICAL
+
+      - name: Upload vulnerability reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kind-vulnerability-reports-${{ github.sha }}
+          path: |
+            trivy-amd64.json
+            trivy-arm64.json
+          if-no-files-found: error
+
+      - name: Enforce vulnerability policy
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          findings=0
+          for report in trivy-amd64.json trivy-arm64.json; do
+            count="$(jq '[.Results[]?.Vulnerabilities[]?] | length' "${report}")"
+            printf '%s: %s critical finding(s)\n' "${report}" "${count}"
+            if (( count > 0 )); then
+              jq -r '
+                .Results[]? as $result
+                | $result.Vulnerabilities[]?
+                | [
+                    $result.Target,
+                    .PkgName,
+                    .InstalledVersion,
+                    (.FixedVersion // "unfixed"),
+                    .VulnerabilityID,
+                    .Title
+                  ]
+                | @tsv
+              ' "${report}"
+              findings=1
+            fi
+          done
+
+          exit "${findings}"
 
   release:
     name: Publish or promote image

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,10 @@
+misconfigurations:
+  - id: AVD-DS-0002
+    paths:
+      - container/kind/Dockerfile
+    expired_at: 2027-07-21
+    statement: >-
+      This image is a client for the host container runtime. Mounting the Docker
+      socket grants root-equivalent host control regardless of the container UID.
+      Socket access is documented as privileged and restricted to explicit,
+      trusted execution. Reassess this exception before its expiration.

--- a/container/kind/Dockerfile
+++ b/container/kind/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1.7
+# SPDX-License-Identifier: Apache-2.0
+
+FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
+
+ARG KIND_VERSION=v0.32.0
+ARG TARGETARCH
+ARG TARGETOS=linux
+
+LABEL org.opencontainers.image.title="kind CLI" \
+      org.opencontainers.image.description="Containerized client environment for the Kubernetes kind CLI" \
+      org.opencontainers.image.source="https://github.com/sentenz/template-k8s" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+RUN set -eux; \
+    apk add --no-cache \
+      ca-certificates \
+      curl \
+      docker-cli; \
+    if [ "${TARGETOS}" != "linux" ]; then \
+      echo "Unsupported target operating system: ${TARGETOS}" >&2; \
+      exit 1; \
+    fi; \
+    arch="${TARGETARCH}"; \
+    if [ -z "${arch}" ]; then \
+      case "$(uname -m)" in \
+        x86_64) arch="amd64" ;; \
+        aarch64) arch="arm64" ;; \
+        *) echo "Unsupported build architecture: $(uname -m)" >&2; exit 1 ;; \
+      esac; \
+    fi; \
+    case "${arch}" in \
+      amd64|arm64) ;; \
+      *) echo "Unsupported target architecture: ${arch}" >&2; exit 1 ;; \
+    esac; \
+    binary="kind-linux-${arch}"; \
+    release_url="https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}"; \
+    curl -fsSLo "/tmp/${binary}" "${release_url}/${binary}"; \
+    curl -fsSLo "/tmp/${binary}.sha256sum" "${release_url}/${binary}.sha256sum"; \
+    cd /tmp; \
+    sha256sum -c "${binary}.sha256sum"; \
+    mv "${binary}" /usr/local/bin/kind; \
+    chmod 0755 /usr/local/bin/kind; \
+    rm -f "${binary}.sha256sum"
+
+WORKDIR /workspace
+
+ENTRYPOINT ["kind"]
+CMD ["version"]

--- a/container/kind/Dockerfile
+++ b/container/kind/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 # SPDX-License-Identifier: Apache-2.0
 
-FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 ARG KIND_VERSION=v0.32.0
 ARG TARGETARCH

--- a/container/kind/README.md
+++ b/container/kind/README.md
@@ -41,20 +41,23 @@ Create the repository development cluster with the host Docker daemon:
 
 ```bash
 docker run --rm \
+  --network host \
   --volume /var/run/docker.sock:/var/run/docker.sock \
   --volume "$PWD:/workspace" \
   --workdir /workspace \
   ghcr.io/sentenz/kind:v0.32.0 \
   create cluster \
+  --name template-k8s \
   --config config/kind-cluster.yaml
 ```
 
-The repository mount exposes the Kind configuration to the CLI container. The Docker socket allows kind to create and manage node containers on the host daemon.
+The repository mount exposes the Kind configuration to the CLI container. The Docker socket allows kind to create and manage node containers on the host daemon. Host networking keeps the CLI container in the same loopback namespace as the Docker host so it can reach the Kubernetes API endpoint created by kind. On Docker Desktop, host networking must be supported and enabled; otherwise use a runtime-specific API address that is reachable from the CLI container.
 
 Delete the cluster with the same execution model:
 
 ```bash
 docker run --rm \
+  --network host \
   --volume /var/run/docker.sock:/var/run/docker.sock \
   ghcr.io/sentenz/kind:v0.32.0 \
   delete cluster \
@@ -77,14 +80,14 @@ The repository's existing `helm/kind-action` integration remains the default Git
 
 ## Publication
 
-The `.github/workflows/kind-container.yml` workflow validates the image on pull requests and pushes that modify the container implementation.
+The `.github/workflows/kind-container.yml` workflow validates image changes on pull requests and runs on pushes to `main` so tag-triggered publication remains reliable.
 
 Immutable version publication uses either:
 
 - a trusted tag named `kind-v<version>`, for example `kind-v0.32.0`; or
 - a manually dispatched workflow with `publish` enabled and an explicit `kind-version` value.
 
-The workflow refuses to overwrite an existing version tag in `ghcr.io/sentenz/kind`. The optional `latest` tag is updated only when `update-latest` is explicitly enabled during a manual publication.
+Publication jobs are serialized by the resolved kind version, and the workflow refuses to overwrite an existing version tag in `ghcr.io/sentenz/kind`. The optional `latest` tag is updated only when `update-latest` is explicitly enabled during a manual publication.
 
 Published images target `linux/amd64` and `linux/arm64`, include OCI metadata, BuildKit provenance, and an SBOM, and are scanned for critical vulnerabilities.
 

--- a/container/kind/README.md
+++ b/container/kind/README.md
@@ -18,7 +18,7 @@ docker build \
 
 The Dockerfile downloads the selected kind release binary and verifies it using the checksum published with that release. The default Alpine base image is pinned by digest.
 
-Build both supported platforms with Buildx:
+Build and publish both supported platforms with Buildx:
 
 ```bash
 docker buildx build \
@@ -26,6 +26,7 @@ docker buildx build \
   --build-arg KIND_VERSION=v0.32.0 \
   --tag ghcr.io/sentenz/kind:v0.32.0 \
   --file container/kind/Dockerfile \
+  --push \
   .
 ```
 
@@ -80,15 +81,20 @@ The repository's existing `helm/kind-action` integration remains the default Git
 
 ## Publication
 
-The `.github/workflows/kind-container.yml` workflow validates image changes on pull requests and runs on pushes to `main` so tag-triggered publication remains reliable.
+The `.github/workflows/kind-container.yml` workflow validates image changes on pull requests and relevant pushes to `main`. Trusted `kind-v*` tag pushes remain publication triggers.
 
 Immutable version publication uses either:
 
 - a trusted tag named `kind-v<version>`, for example `kind-v0.32.0`; or
-- a manually dispatched workflow with `publish` enabled and an explicit `kind-version` value.
+- a manually dispatched workflow with `publish` enabled and an explicit `kind_version` value.
 
-Publication jobs are serialized by the resolved kind version, and the workflow refuses to overwrite an existing version tag in `ghcr.io/sentenz/kind`. The optional `latest` tag is updated only when `update-latest` is explicitly enabled during a manual publication.
+For a new release, the workflow builds separate `linux/amd64` and `linux/arm64` candidates, publishes them by digest without a version tag, and scans each candidate for critical operating-system and library vulnerabilities. The immutable version manifest is created only after both scans pass. Published platform images include OCI metadata, BuildKit provenance, and an SBOM.
 
-Published images target `linux/amd64` and `linux/arm64`, include OCI metadata, BuildKit provenance, and an SBOM, and are scanned for critical vulnerabilities.
+Publication operations are serialized by the resolved kind version, and the workflow refuses to overwrite an existing version tag in `ghcr.io/sentenz/kind`.
+
+The moving `latest` tag is managed as a separate promotion operation:
+
+- publish a new version and promote it in one dispatch by enabling both `publish` and `update_latest`; or
+- promote an existing immutable version by setting `publish` to false, enabling `update_latest`, and selecting its `kind_version`.
 
 A full cluster-creation test is available only through explicit manual dispatch. It mounts the Docker socket on a trusted ephemeral GitHub-hosted runner and is intentionally excluded from pull-request execution.

--- a/container/kind/README.md
+++ b/container/kind/README.md
@@ -1,0 +1,91 @@
+# kind CLI Container
+
+The `ghcr.io/sentenz/kind` image provides a small, versioned execution environment for the [`kind`](https://kind.sigs.k8s.io/) CLI.
+
+This image is a client-side tool container. It does not replace `kindest/node`, which remains the Kubernetes node image used by clusters created with kind.
+
+## Build
+
+Build the image for the host architecture:
+
+```bash
+docker build \
+  --build-arg KIND_VERSION=v0.32.0 \
+  --tag ghcr.io/sentenz/kind:v0.32.0 \
+  --file container/kind/Dockerfile \
+  .
+```
+
+The Dockerfile downloads the selected kind release binary and verifies it using the checksum published with that release. The default Alpine base image is pinned by digest.
+
+Build both supported platforms with Buildx:
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --build-arg KIND_VERSION=v0.32.0 \
+  --tag ghcr.io/sentenz/kind:v0.32.0 \
+  --file container/kind/Dockerfile \
+  .
+```
+
+## Run
+
+Display the embedded kind version:
+
+```bash
+docker run --rm ghcr.io/sentenz/kind:v0.32.0 version
+```
+
+Create the repository development cluster with the host Docker daemon:
+
+```bash
+docker run --rm \
+  --volume /var/run/docker.sock:/var/run/docker.sock \
+  --volume "$PWD:/workspace" \
+  --workdir /workspace \
+  ghcr.io/sentenz/kind:v0.32.0 \
+  create cluster \
+  --config config/kind-cluster.yaml
+```
+
+The repository mount exposes the Kind configuration to the CLI container. The Docker socket allows kind to create and manage node containers on the host daemon.
+
+Delete the cluster with the same execution model:
+
+```bash
+docker run --rm \
+  --volume /var/run/docker.sock:/var/run/docker.sock \
+  ghcr.io/sentenz/kind:v0.32.0 \
+  delete cluster \
+  --name template-k8s
+```
+
+## Security model
+
+Mounting `/var/run/docker.sock` grants the container effectively privileged control over the host Docker daemon. A process with access to that socket can create privileged containers, mount host paths, and modify or remove host containers and images. This execution model is not a sandbox or a least-privilege boundary.
+
+Accordingly:
+
+- do not expose the Docker socket to untrusted pull-request code or untrusted image contents;
+- use an isolated or ephemeral runner when containerized kind execution is required in automation;
+- prefer installing the kind release binary directly, or retain the repository's `helm/kind-action` integration, when a containerized toolchain is not required;
+- use a rootless Docker or Podman socket only where the selected runtime and kind configuration are explicitly supported, and mount the runtime-specific socket rather than assuming `/var/run/docker.sock`;
+- treat membership in the host runtime socket group as privileged access.
+
+The repository's existing `helm/kind-action` integration remains the default GitHub Actions path. The custom image is built, scanned, and smoke-tested independently.
+
+## Publication
+
+The `.github/workflows/kind-container.yml` workflow validates the image on pull requests and pushes that modify the container implementation.
+
+Immutable version publication uses either:
+
+- a trusted tag named `kind-v<version>`, for example `kind-v0.32.0`; or
+- a manually dispatched workflow with `publish` enabled and an explicit `kind-version` value.
+
+The workflow refuses to overwrite an existing version tag in `ghcr.io/sentenz/kind`. The optional `latest` tag is updated only when `update-latest` is explicitly enabled during a manual publication.
+
+Published images target `linux/amd64` and `linux/arm64`, include OCI metadata, BuildKit provenance, and an SBOM, and are scanned for critical vulnerabilities.
+
+A full cluster-creation test is available only through explicit manual dispatch. It mounts the Docker socket on a trusted ephemeral GitHub-hosted runner and is intentionally excluded from pull-request execution.

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -26,7 +26,7 @@ dependency-tree: false
 exit-code: 0
 exit-on-eol: 0
 ignore-policy: ""
-ignorefile: .trivyignore
+ignorefile: .trivyignore.yaml
 image:
   docker:
     host: ""

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,7 +1,7 @@
 cacert: ""
 cache:
   backend: fs
-  dir: /root/.cache/trivy
+  dir: .cache/trivy
   redis:
     ca: ""
     cert: ""
@@ -221,7 +221,7 @@ misconfiguration:
     exclude-downloaded-modules: false
     vars: []
 module:
-  dir: /root/.trivy/modules
+  dir: .cache/trivy/modules
   enable-modules: []
 output: ""
 output-plugin-arg: ""


### PR DESCRIPTION
## Summary

- add `container/kind/Dockerfile` for a versioned, checksum-verified kind CLI image
- pin the Alpine base image by multi-platform digest
- include `ca-certificates`, `curl`, and the Docker CLI runtime client
- document local build and execution with `config/kind-cluster.yaml`
- document the privilege implications of mounting `/var/run/docker.sock`
- add an isolated workflow for amd64/arm64 validation and GHCR publication
- generate OCI metadata, BuildKit provenance, and an SBOM for published images
- scan amd64 and arm64 candidates for critical OS and library vulnerabilities before assigning release tags
- smoke-test `kind version`
- provide an opt-in trusted-runner cluster creation test without replacing the existing `helm/kind-action` integration
- make Trivy cache paths portable across non-root CI runners
- record a path-scoped, expiring exception for the Docker-socket client image's root-user finding

## Publication model

Immutable images are published as `ghcr.io/sentenz/kind:vX.Y.Z` from trusted `kind-vX.Y.Z` tags or an explicit manual dispatch. Each platform candidate is pushed by digest and scanned before the immutable version manifest is created. Existing version tags are not overwritten.

Updating `latest` is a separate explicit promotion operation. A manual dispatch can publish and promote a new version in one run, or promote an already-published immutable version without rebuilding it.

## Security

The documentation states that access to the Docker socket is effectively privileged host access. Pull-request workflows do not mount the socket; cluster creation is available only through explicit manual dispatch on an ephemeral runner.

The generic non-root-image check is suppressed only for `container/kind/Dockerfile`, with an explicit rationale and an expiration date of 2027-07-21. Docker-socket access remains root-equivalent host access regardless of the container UID.

## Validation

- Dockerfile checksum verification for the selected kind release
- separate builds for `linux/amd64` and `linux/arm64`
- local `kind version` smoke test on amd64
- Trivy critical-vulnerability scans covering OS packages and compiled-library dependencies on both architectures
- retained per-platform JSON reports and scanner logs
- release tags created only after both candidate scans pass
- optional full cluster creation using `config/kind-cluster.yaml`

Closes #42