### PR TITLE
refactor(ci): publish container images from repository releases

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -172,44 +172,46 @@ jobs:
         shell: bash
         run: bash -n scripts/bootstrap.sh
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - name: Validate multi-platform image build
+        uses: sentenz/actions/container-image@edd5e1e574e3eaa1254fbd19f4d2f0a5854c574d # v1.2.1
         with:
-          platforms: amd64,arm64
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-
-      - name: Build local amd64 image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: .
+          version: validate-${{ github.sha }}
+          image-name: k8s
           file: container/k8s/Dockerfile
-          platforms: linux/amd64
-          load: true
-          tags: local/k8s:${{ github.sha }}-amd64
-          provenance: false
-          sbom: false
+          platforms: linux/amd64,linux/arm64
+          push: false
           build-args: |
             KUBECTL_VERSION=${{ needs.prepare.outputs.kubectl_version }}
             KUSTOMIZE_VERSION=${{ needs.prepare.outputs.kustomize_version }}
             KIND_VERSION=${{ needs.prepare.outputs.kind_version }}
             HELM_VERSION=${{ needs.prepare.outputs.helm_version }}
+            IMAGE_VERSION=${{ needs.prepare.outputs.image_version }}
+            VCS_REF=${{ github.sha }}
 
-      - name: Build arm64 image archive
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: .
-          file: container/k8s/Dockerfile
-          platforms: linux/arm64
-          outputs: type=docker,dest=${{ runner.temp }}/k8s-arm64.tar
-          provenance: false
-          sbom: false
-          build-args: |
-            KUBECTL_VERSION=${{ needs.prepare.outputs.kubectl_version }}
-            KUSTOMIZE_VERSION=${{ needs.prepare.outputs.kustomize_version }}
-            KIND_VERSION=${{ needs.prepare.outputs.kind_version }}
-            HELM_VERSION=${{ needs.prepare.outputs.helm_version }}
+      - name: Build local amd64 smoke-test image
+        shell: bash
+        env:
+          IMAGE_VERSION: ${{ needs.prepare.outputs.image_version }}
+          KUBECTL_VERSION: ${{ needs.prepare.outputs.kubectl_version }}
+          KUSTOMIZE_VERSION: ${{ needs.prepare.outputs.kustomize_version }}
+          KIND_VERSION: ${{ needs.prepare.outputs.kind_version }}
+          HELM_VERSION: ${{ needs.prepare.outputs.helm_version }}
+          TEST_IMAGE: local/k8s:${{ github.sha }}-amd64
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --platform linux/amd64 \
+            --file container/k8s/Dockerfile \
+            --tag "${TEST_IMAGE}" \
+            --load \
+            --provenance=false \
+            --build-arg "KUBECTL_VERSION=${KUBECTL_VERSION}" \
+            --build-arg "KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION}" \
+            --build-arg "KIND_VERSION=${KIND_VERSION}" \
+            --build-arg "HELM_VERSION=${HELM_VERSION}" \
+            --build-arg "IMAGE_VERSION=${IMAGE_VERSION}" \
+            --build-arg "VCS_REF=${GITHUB_SHA}" \
+            .
 
       - name: Smoke test toolchain
         shell: bash
@@ -232,12 +234,6 @@ jobs:
           grep -F -- "${EXPECTED_KUSTOMIZE_VERSION#v}" <<< "${kustomize_output}"
           grep -F -- "${EXPECTED_KIND_VERSION#v}" <<< "${kind_output}"
           grep -F -- "${EXPECTED_HELM_VERSION}" <<< "${helm_output}"
-
-      - name: Export amd64 image archive
-        shell: bash
-        env:
-          TEST_IMAGE: local/k8s:${{ github.sha }}-amd64
-        run: docker save --output "${RUNNER_TEMP}/k8s-amd64.tar" "${TEST_IMAGE}"
 
   release:
     name: Publish or promote image
@@ -266,13 +262,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up QEMU
-        if: env.PUBLISH_VERSION == 'true'
+      - name: Set up QEMU for immutable-only publication
+        if: env.PUBLISH_VERSION == 'true' && env.UPDATE_LATEST != 'true'
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
           platforms: amd64,arm64
 
-      - name: Set up Docker Buildx
+      - name: Set up Docker Buildx for manual release operations
+        if: env.PUBLISH_VERSION != 'true' || env.UPDATE_LATEST != 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Log in to GHCR
@@ -289,7 +286,7 @@ jobs:
           version_image="${IMAGE_NAME}:${IMAGE_VERSION}"
 
           if [[ "${PUBLISH_VERSION}" == true ]]; then
-            if docker buildx imagetools inspect "${version_image}" >/dev/null 2>&1; then
+            if docker manifest inspect "${version_image}" >/dev/null 2>&1; then
               echo "Refusing to overwrite existing immutable tag: ${version_image}" >&2
               exit 1
             fi
@@ -298,82 +295,59 @@ jobs:
             exit 1
           fi
 
-      - name: Generate OCI metadata
-        if: env.PUBLISH_VERSION == 'true'
-        id: metadata
-        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
+      - name: Build and publish version with latest
+        if: env.PUBLISH_VERSION == 'true' && env.UPDATE_LATEST == 'true'
+        id: image
+        uses: sentenz/actions/container-image@edd5e1e574e3eaa1254fbd19f4d2f0a5854c574d # v1.2.1
         with:
-          images: ${{ env.IMAGE_NAME }}
-          labels: |
-            org.opencontainers.image.title=Kubernetes toolchain
-            org.opencontainers.image.description=Verified kubectl, Kustomize, kind, and Helm toolchain
-            org.opencontainers.image.url=https://github.com/sentenz/template-k8s
-            org.opencontainers.image.source=https://github.com/sentenz/template-k8s
-            org.opencontainers.image.version=${{ needs.prepare.outputs.image_version }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.licenses=Apache-2.0
-
-      - name: Build and push amd64 release candidate
-        if: env.PUBLISH_VERSION == 'true'
-        id: build_amd64
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: .
+          version: ${{ env.IMAGE_VERSION }}
+          image-name: k8s
           file: container/k8s/Dockerfile
-          platforms: linux/amd64
-          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-          labels: ${{ steps.metadata.outputs.labels }}
-          provenance: mode=max
-          sbom: true
+          platforms: linux/amd64,linux/arm64
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           build-args: |
             KUBECTL_VERSION=${{ needs.prepare.outputs.kubectl_version }}
             KUSTOMIZE_VERSION=${{ needs.prepare.outputs.kustomize_version }}
             KIND_VERSION=${{ needs.prepare.outputs.kind_version }}
             HELM_VERSION=${{ needs.prepare.outputs.helm_version }}
+            IMAGE_VERSION=${{ needs.prepare.outputs.image_version }}
+            VCS_REF=${{ github.sha }}
 
-      - name: Build and push arm64 release candidate
-        if: env.PUBLISH_VERSION == 'true'
-        id: build_arm64
+      - name: Build and publish immutable version only
+        if: env.PUBLISH_VERSION == 'true' && env.UPDATE_LATEST != 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: container/k8s/Dockerfile
-          platforms: linux/arm64
-          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-          labels: ${{ steps.metadata.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
           provenance: mode=max
           sbom: true
+          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}
+          cache-to: type=gha,mode=max,scope=${{ env.IMAGE_NAME }}
           build-args: |
             KUBECTL_VERSION=${{ needs.prepare.outputs.kubectl_version }}
             KUSTOMIZE_VERSION=${{ needs.prepare.outputs.kustomize_version }}
             KIND_VERSION=${{ needs.prepare.outputs.kind_version }}
             HELM_VERSION=${{ needs.prepare.outputs.helm_version }}
-
-      - name: Publish immutable version tag
-        if: env.PUBLISH_VERSION == 'true'
-        shell: bash
-        env:
-          AMD64_DIGEST: ${{ steps.build_amd64.outputs.digest }}
-          ARM64_DIGEST: ${{ steps.build_arm64.outputs.digest }}
-        run: |
-          set -euo pipefail
-          version_image="${IMAGE_NAME}:${IMAGE_VERSION}"
-          docker buildx imagetools create \
-            --tag "${version_image}" \
-            "${IMAGE_NAME}@${AMD64_DIGEST}" \
-            "${IMAGE_NAME}@${ARM64_DIGEST}"
-          docker buildx imagetools inspect "${version_image}"
+            IMAGE_VERSION=${{ needs.prepare.outputs.image_version }}
+            VCS_REF=${{ github.sha }}
 
       - name: Promote immutable version to latest
-        if: env.UPDATE_LATEST == 'true'
+        if: env.PUBLISH_VERSION != 'true' && env.UPDATE_LATEST == 'true'
         shell: bash
         run: |
           set -euo pipefail
           version_image="${IMAGE_NAME}:${IMAGE_VERSION}"
           latest_image="${IMAGE_NAME}:latest"
-          docker buildx imagetools inspect "${version_image}"
           docker buildx imagetools create --tag "${latest_image}" "${version_image}"
           docker buildx imagetools inspect "${latest_image}"
+
+      - name: Verify immutable version
+        if: env.PUBLISH_VERSION == 'true'
+        shell: bash
+        run: docker buildx imagetools inspect "${IMAGE_NAME}:${IMAGE_VERSION}"
 
   cluster-test:
     name: Create cluster through toolchain container
@@ -406,6 +380,8 @@ jobs:
             KUSTOMIZE_VERSION=${{ needs.prepare.outputs.kustomize_version }}
             KIND_VERSION=${{ needs.prepare.outputs.kind_version }}
             HELM_VERSION=${{ needs.prepare.outputs.helm_version }}
+            IMAGE_VERSION=cluster-test
+            VCS_REF=${{ github.sha }}
 
       - name: Create cluster
         shell: bash

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate container image
-        uses: sentenz/actions/container-image@3e3a5a186498edf6b52f5f80b30a1b637c8be23a # PR sentenz/actions#57
+        uses: sentenz/actions/container-image@5c5271be112f7544262538c2b7ee6701efc9921f # PR sentenz/actions#57
         with:
           operation: build
           version: sha-${{ github.sha }}
@@ -60,7 +60,7 @@ jobs:
           persist-credentials: false
 
       - name: Publish container image
-        uses: sentenz/actions/container-image@3e3a5a186498edf6b52f5f80b30a1b637c8be23a # PR sentenz/actions#57
+        uses: sentenz/actions/container-image@5c5271be112f7544262538c2b7ee6701efc9921f # PR sentenz/actions#57
         with:
           operation: publish
           version: ${{ github.event.release.tag_name }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -6,8 +6,7 @@ on:
   pull_request:
     paths:
       - container/k8s/**
-      - scripts/*.sh
-      - Makefile
+      - scripts/bootstrap.sh
       - .github/workflows/container.yml
   push:
     branches:
@@ -16,16 +15,32 @@ on:
       - "v*.*.*"
     paths:
       - container/k8s/**
-      - scripts/*.sh
-      - Makefile
+      - scripts/bootstrap.sh
       - .github/workflows/container.yml
   workflow_dispatch:
     inputs:
-      image_version:
-        description: Immutable image version to publish or promote
+      operation:
+        description: Container image operation
         required: true
-        default: v1.0.0
+        default: build
+        type: choice
+        options:
+          - build
+          - publish
+          - promote
+      image_version:
+        description: Immutable image version for manual publish or promote operations
+        required: false
         type: string
+      publish_latest:
+        description: Latest-tag policy
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - "true"
+          - "false"
       kubectl_version:
         description: kubectl release version
         required: true
@@ -46,378 +61,39 @@ on:
         required: true
         default: v4.2.2
         type: string
-      publish:
-        description: Publish a new immutable version to GHCR
-        required: true
-        default: false
-        type: boolean
-      update_latest:
-        description: Promote the selected immutable version to latest
-        required: true
-        default: false
-        type: boolean
-      run_cluster_test:
-        description: Create and delete a cluster using the host Docker socket
-        required: true
-        default: false
-        type: boolean
 
 concurrency:
-  group: k8s-container-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ inputs.image_version || 'default' }}
+  group: container-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
-
-env:
-  DEFAULT_KUBECTL_VERSION: v1.36.1
-  DEFAULT_KUSTOMIZE_VERSION: v5.8.1
-  DEFAULT_KIND_VERSION: v0.32.0
-  DEFAULT_HELM_VERSION: v4.2.2
-  IMAGE_NAME: ghcr.io/sentenz/k8s
+  packages: write
 
 jobs:
-  prepare:
-    name: Resolve release configuration
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    outputs:
-      image_version: ${{ steps.resolve.outputs.image_version }}
-      kubectl_version: ${{ steps.resolve.outputs.kubectl_version }}
-      kustomize_version: ${{ steps.resolve.outputs.kustomize_version }}
-      kind_version: ${{ steps.resolve.outputs.kind_version }}
-      helm_version: ${{ steps.resolve.outputs.helm_version }}
-      publish: ${{ steps.resolve.outputs.publish }}
-      update_latest: ${{ steps.resolve.outputs.update_latest }}
-    steps:
-      - name: Resolve and validate inputs
-        id: resolve
-        shell: bash
-        env:
-          DISPATCH_IMAGE_VERSION: ${{ inputs.image_version }}
-          DISPATCH_KUBECTL_VERSION: ${{ inputs.kubectl_version }}
-          DISPATCH_KUSTOMIZE_VERSION: ${{ inputs.kustomize_version }}
-          DISPATCH_KIND_VERSION: ${{ inputs.kind_version }}
-          DISPATCH_HELM_VERSION: ${{ inputs.helm_version }}
-          DISPATCH_PUBLISH: ${{ inputs.publish }}
-          DISPATCH_UPDATE_LATEST: ${{ inputs.update_latest }}
-        run: |
-          set -euo pipefail
-
-          image_version=dev
-          kubectl_version="${DEFAULT_KUBECTL_VERSION}"
-          kustomize_version="${DEFAULT_KUSTOMIZE_VERSION}"
-          kind_version="${DEFAULT_KIND_VERSION}"
-          helm_version="${DEFAULT_HELM_VERSION}"
-          publish=false
-          update_latest=false
-
-          if [[ "${GITHUB_REF_TYPE}" == tag ]]; then
-            image_version="${GITHUB_REF_NAME}"
-            publish=true
-            if [[ "${image_version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              update_latest=true
-            fi
-          elif [[ "${GITHUB_EVENT_NAME}" == workflow_dispatch ]]; then
-            image_version="${DISPATCH_IMAGE_VERSION}"
-            kubectl_version="${DISPATCH_KUBECTL_VERSION}"
-            kustomize_version="${DISPATCH_KUSTOMIZE_VERSION}"
-            kind_version="${DISPATCH_KIND_VERSION}"
-            helm_version="${DISPATCH_HELM_VERSION}"
-            publish="${DISPATCH_PUBLISH}"
-            update_latest="${DISPATCH_UPDATE_LATEST}"
-          fi
-
-          version_pattern='^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z][0-9A-Za-z.-]*)?$'
-          for value in \
-            "${kubectl_version}" \
-            "${kustomize_version}" \
-            "${kind_version}" \
-            "${helm_version}"; do
-            if ! [[ "${value}" =~ ${version_pattern} ]]; then
-              echo "Invalid tool version: ${value}" >&2
-              exit 1
-            fi
-          done
-
-          if [[ "${publish}" == true || "${update_latest}" == true ]]; then
-            if ! [[ "${image_version}" =~ ${version_pattern} ]]; then
-              echo "Invalid image version: ${image_version}" >&2
-              exit 1
-            fi
-          fi
-
-          {
-            echo "image_version=${image_version}"
-            echo "kubectl_version=${kubectl_version}"
-            echo "kustomize_version=${kustomize_version}"
-            echo "kind_version=${kind_version}"
-            echo "helm_version=${helm_version}"
-            echo "publish=${publish}"
-            echo "update_latest=${update_latest}"
-          } >> "${GITHUB_OUTPUT}"
-
-  validate:
-    name: Build and smoke test
-    needs: prepare
-    runs-on: ubuntu-24.04
-    timeout-minutes: 40
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          persist-credentials: false
-
-      - name: Validate installer syntax
-        shell: bash
-        run: bash -n scripts/bootstrap.sh
-
-      - name: Validate multi-platform image build
-        uses: sentenz/actions/container-image@edd5e1e574e3eaa1254fbd19f4d2f0a5854c574d # v1.2.1
-        with:
-          version: validate-${{ github.sha }}
-          image-name: k8s
-          file: container/k8s/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: false
-          build-args: |
-            KUBECTL_VERSION=${{ needs.prepare.outputs.kubectl_version }}
-            KUSTOMIZE_VERSION=${{ needs.prepare.outputs.kustomize_version }}
-            KIND_VERSION=${{ needs.prepare.outputs.kind_version }}
-            HELM_VERSION=${{ needs.prepare.outputs.helm_version }}
-            IMAGE_VERSION=${{ needs.prepare.outputs.image_version }}
-            VCS_REF=${{ github.sha }}
-
-      - name: Build local amd64 smoke-test image
-        shell: bash
-        env:
-          IMAGE_VERSION: ${{ needs.prepare.outputs.image_version }}
-          KUBECTL_VERSION: ${{ needs.prepare.outputs.kubectl_version }}
-          KUSTOMIZE_VERSION: ${{ needs.prepare.outputs.kustomize_version }}
-          KIND_VERSION: ${{ needs.prepare.outputs.kind_version }}
-          HELM_VERSION: ${{ needs.prepare.outputs.helm_version }}
-          TEST_IMAGE: local/k8s:${{ github.sha }}-amd64
-        run: |
-          set -euo pipefail
-          docker buildx build \
-            --platform linux/amd64 \
-            --file container/k8s/Dockerfile \
-            --tag "${TEST_IMAGE}" \
-            --load \
-            --provenance=false \
-            --build-arg "KUBECTL_VERSION=${KUBECTL_VERSION}" \
-            --build-arg "KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION}" \
-            --build-arg "KIND_VERSION=${KIND_VERSION}" \
-            --build-arg "HELM_VERSION=${HELM_VERSION}" \
-            --build-arg "IMAGE_VERSION=${IMAGE_VERSION}" \
-            --build-arg "VCS_REF=${GITHUB_SHA}" \
-            .
-
-      - name: Smoke test toolchain
-        shell: bash
-        env:
-          TEST_IMAGE: local/k8s:${{ github.sha }}-amd64
-          EXPECTED_KUBECTL_VERSION: ${{ needs.prepare.outputs.kubectl_version }}
-          EXPECTED_KUSTOMIZE_VERSION: ${{ needs.prepare.outputs.kustomize_version }}
-          EXPECTED_KIND_VERSION: ${{ needs.prepare.outputs.kind_version }}
-          EXPECTED_HELM_VERSION: ${{ needs.prepare.outputs.helm_version }}
-        run: |
-          set -euo pipefail
-
-          kubectl_output="$(docker run --rm "${TEST_IMAGE}" kubectl version --client=true --output=yaml)"
-          kustomize_output="$(docker run --rm "${TEST_IMAGE}" kustomize version)"
-          kind_output="$(docker run --rm "${TEST_IMAGE}" kind version)"
-          helm_output="$(docker run --rm "${TEST_IMAGE}" helm version --short)"
-
-          printf '%s\n' "${kubectl_output}" "${kustomize_output}" "${kind_output}" "${helm_output}"
-          grep -F -- "${EXPECTED_KUBECTL_VERSION}" <<< "${kubectl_output}"
-          grep -F -- "${EXPECTED_KUSTOMIZE_VERSION#v}" <<< "${kustomize_output}"
-          grep -F -- "${EXPECTED_KIND_VERSION#v}" <<< "${kind_output}"
-          grep -F -- "${EXPECTED_HELM_VERSION}" <<< "${helm_output}"
-
-  release:
-    name: Publish or promote image
-    needs:
-      - prepare
-      - validate
-    if: >-
-      needs.validate.result == 'success' &&
-      (needs.prepare.outputs.publish == 'true' || needs.prepare.outputs.update_latest == 'true')
-    concurrency:
-      group: k8s-container-release-${{ needs.prepare.outputs.image_version }}
-      cancel-in-progress: false
+  image:
+    name: Build or Publish Kubernetes Toolchain
     runs-on: ubuntu-24.04
     timeout-minutes: 60
-    permissions:
-      contents: read
-      packages: write
-    env:
-      IMAGE_VERSION: ${{ needs.prepare.outputs.image_version }}
-      PUBLISH_VERSION: ${{ needs.prepare.outputs.publish }}
-      UPDATE_LATEST: ${{ needs.prepare.outputs.update_latest }}
     steps:
       - name: Checkout
-        if: env.PUBLISH_VERSION == 'true'
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
-      - name: Set up QEMU for immutable-only publication
-        if: env.PUBLISH_VERSION == 'true' && env.UPDATE_LATEST != 'true'
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - name: Build, publish, or promote image
+        uses: sentenz/actions/container-image@3e3a5a186498edf6b52f5f80b30a1b637c8be23a # PR sentenz/actions#57
         with:
-          platforms: amd64,arm64
-
-      - name: Set up Docker Buildx for manual release operations
-        if: env.PUBLISH_VERSION != 'true' || env.UPDATE_LATEST != 'true'
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-
-      - name: Log in to GHCR
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Validate release operation
-        shell: bash
-        run: |
-          set -euo pipefail
-          version_image="${IMAGE_NAME}:${IMAGE_VERSION}"
-
-          if [[ "${PUBLISH_VERSION}" == true ]]; then
-            if docker manifest inspect "${version_image}" >/dev/null 2>&1; then
-              echo "Refusing to overwrite existing immutable tag: ${version_image}" >&2
-              exit 1
-            fi
-          elif ! docker buildx imagetools inspect "${version_image}" >/dev/null 2>&1; then
-            echo "Cannot promote missing immutable tag: ${version_image}" >&2
-            exit 1
-          fi
-
-      - name: Build and publish version with latest
-        if: env.PUBLISH_VERSION == 'true' && env.UPDATE_LATEST == 'true'
-        id: image
-        uses: sentenz/actions/container-image@edd5e1e574e3eaa1254fbd19f4d2f0a5854c574d # v1.2.1
-        with:
-          version: ${{ env.IMAGE_VERSION }}
+          operation: ${{ inputs.operation || 'auto' }}
+          version: ${{ inputs.image_version }}
+          publish-latest: ${{ inputs.publish_latest || 'auto' }}
+          immutable: true
           image-name: k8s
           file: container/k8s/Dockerfile
           platforms: linux/amd64,linux/arm64
           github-token: ${{ secrets.GITHUB_TOKEN }}
           build-args: |
-            KUBECTL_VERSION=${{ needs.prepare.outputs.kubectl_version }}
-            KUSTOMIZE_VERSION=${{ needs.prepare.outputs.kustomize_version }}
-            KIND_VERSION=${{ needs.prepare.outputs.kind_version }}
-            HELM_VERSION=${{ needs.prepare.outputs.helm_version }}
-            IMAGE_VERSION=${{ needs.prepare.outputs.image_version }}
-            VCS_REF=${{ github.sha }}
-
-      - name: Build and publish immutable version only
-        if: env.PUBLISH_VERSION == 'true' && env.UPDATE_LATEST != 'true'
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: .
-          file: container/k8s/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
-          provenance: mode=max
-          sbom: true
-          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}
-          cache-to: type=gha,mode=max,scope=${{ env.IMAGE_NAME }}
-          build-args: |
-            KUBECTL_VERSION=${{ needs.prepare.outputs.kubectl_version }}
-            KUSTOMIZE_VERSION=${{ needs.prepare.outputs.kustomize_version }}
-            KIND_VERSION=${{ needs.prepare.outputs.kind_version }}
-            HELM_VERSION=${{ needs.prepare.outputs.helm_version }}
-            IMAGE_VERSION=${{ needs.prepare.outputs.image_version }}
-            VCS_REF=${{ github.sha }}
-
-      - name: Promote immutable version to latest
-        if: env.PUBLISH_VERSION != 'true' && env.UPDATE_LATEST == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          version_image="${IMAGE_NAME}:${IMAGE_VERSION}"
-          latest_image="${IMAGE_NAME}:latest"
-          docker buildx imagetools create --tag "${latest_image}" "${version_image}"
-          docker buildx imagetools inspect "${latest_image}"
-
-      - name: Verify immutable version
-        if: env.PUBLISH_VERSION == 'true'
-        shell: bash
-        run: docker buildx imagetools inspect "${IMAGE_NAME}:${IMAGE_VERSION}"
-
-  cluster-test:
-    name: Create cluster through toolchain container
-    if: github.event_name == 'workflow_dispatch' && inputs.run_cluster_test
-    needs:
-      - prepare
-      - validate
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          persist-credentials: false
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-
-      - name: Build local cluster-test image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: .
-          file: container/k8s/Dockerfile
-          load: true
-          tags: local/k8s:cluster-test
-          provenance: false
-          sbom: false
-          build-args: |
-            KUBECTL_VERSION=${{ needs.prepare.outputs.kubectl_version }}
-            KUSTOMIZE_VERSION=${{ needs.prepare.outputs.kustomize_version }}
-            KIND_VERSION=${{ needs.prepare.outputs.kind_version }}
-            HELM_VERSION=${{ needs.prepare.outputs.helm_version }}
-            IMAGE_VERSION=cluster-test
-            VCS_REF=${{ github.sha }}
-
-      - name: Create cluster
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker run --rm \
-            --user root \
-            --network host \
-            --volume /var/run/docker.sock:/var/run/docker.sock \
-            --volume "${GITHUB_WORKSPACE}:/workspace" \
-            --workdir /workspace \
-            local/k8s:cluster-test \
-            kind create cluster \
-            --name template-k8s-container-test \
-            --config config/kind-cluster.yaml \
-            --wait 5m
-
-      - name: Verify cluster nodes
-        shell: bash
-        run: |
-          set -euo pipefail
-          node_count="$({ docker ps --filter label=io.x-k8s.kind.cluster=template-k8s-container-test --format '{{.ID}}'; } | wc -l | tr -d ' ')"
-          if [[ "${node_count}" != 3 ]]; then
-            echo "Expected three kind nodes, found ${node_count}" >&2
-            docker ps --filter label=io.x-k8s.kind.cluster=template-k8s-container-test >&2
-            exit 1
-          fi
-
-      - name: Delete cluster
-        if: always()
-        shell: bash
-        run: |
-          docker run --rm \
-            --user root \
-            --network host \
-            --volume /var/run/docker.sock:/var/run/docker.sock \
-            local/k8s:cluster-test \
-            kind delete cluster \
-            --name template-k8s-container-test
+            KUBECTL_VERSION=${{ inputs.kubectl_version || 'v1.36.1' }}
+            KUSTOMIZE_VERSION=${{ inputs.kustomize_version || 'v5.8.1' }}
+            KIND_VERSION=${{ inputs.kind_version || 'v0.32.0' }}
+            HELM_VERSION=${{ inputs.helm_version || 'v4.2.2' }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,59 +8,9 @@ on:
       - container/k8s/**
       - scripts/bootstrap.sh
       - .github/workflows/container.yml
-  push:
-    branches:
-      - main
-    tags:
-      - "v*.*.*"
-    paths:
-      - container/k8s/**
-      - scripts/bootstrap.sh
-      - .github/workflows/container.yml
-  workflow_dispatch:
-    inputs:
-      operation:
-        description: Container image operation
-        required: true
-        default: build
-        type: choice
-        options:
-          - build
-          - publish
-          - promote
-      image_version:
-        description: Immutable image version for manual publish or promote operations
-        required: false
-        type: string
-      publish_latest:
-        description: Latest-tag policy
-        required: true
-        default: auto
-        type: choice
-        options:
-          - auto
-          - "true"
-          - "false"
-      kubectl_version:
-        description: kubectl release version
-        required: true
-        default: v1.36.1
-        type: string
-      kustomize_version:
-        description: Kustomize release version
-        required: true
-        default: v5.8.1
-        type: string
-      kind_version:
-        description: kind release version
-        required: true
-        default: v0.32.0
-        type: string
-      helm_version:
-        description: Helm release version
-        required: true
-        default: v4.2.2
-        type: string
+  release:
+    types:
+      - published
 
 concurrency:
   group: container-${{ github.workflow }}-${{ github.ref }}
@@ -68,11 +18,11 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
-  image:
-    name: Build or Publish Kubernetes Toolchain
+  validate:
+    name: Validate Kubernetes Toolchain Image
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
@@ -81,19 +31,47 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build, publish, or promote image
+      - name: Validate container image
         uses: sentenz/actions/container-image@3e3a5a186498edf6b52f5f80b30a1b637c8be23a # PR sentenz/actions#57
         with:
-          operation: ${{ inputs.operation || 'auto' }}
-          version: ${{ inputs.image_version }}
-          publish-latest: ${{ inputs.publish_latest || 'auto' }}
+          operation: build
+          version: sha-${{ github.sha }}
+          image-name: k8s
+          file: container/k8s/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            KUBECTL_VERSION=v1.36.1
+            KUSTOMIZE_VERSION=v5.8.1
+            KIND_VERSION=v0.32.0
+            HELM_VERSION=v4.2.2
+
+  publish:
+    name: Publish Kubernetes Toolchain Image
+    if: github.event_name == 'release'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Publish container image
+        uses: sentenz/actions/container-image@3e3a5a186498edf6b52f5f80b30a1b637c8be23a # PR sentenz/actions#57
+        with:
+          operation: publish
+          version: ${{ github.event.release.tag_name }}
+          publish-latest: auto
           immutable: true
           image-name: k8s
           file: container/k8s/Dockerfile
           platforms: linux/amd64,linux/arm64
           github-token: ${{ secrets.GITHUB_TOKEN }}
           build-args: |
-            KUBECTL_VERSION=${{ inputs.kubectl_version || 'v1.36.1' }}
-            KUSTOMIZE_VERSION=${{ inputs.kustomize_version || 'v5.8.1' }}
-            KIND_VERSION=${{ inputs.kind_version || 'v0.32.0' }}
-            HELM_VERSION=${{ inputs.helm_version || 'v4.2.2' }}
+            KUBECTL_VERSION=v1.36.1
+            KUSTOMIZE_VERSION=v5.8.1
+            KIND_VERSION=v0.32.0
+            HELM_VERSION=v4.2.2

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -31,18 +31,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Validate installer syntax
-        shell: bash
-        run: bash -n scripts/bootstrap.sh
-
       - name: Validate multi-platform container image
-        uses: sentenz/actions/container-image@5c5271be112f7544262538c2b7ee6701efc9921f # sentenz/actions#57
+        uses: sentenz/actions/container-image@618e0bd890f8a03959ea0646473b2b7c6a8db862
         with:
-          operation: build
           version: sha-${{ github.sha }}
           image-name: k8s
           file: container/k8s/Dockerfile
           platforms: linux/amd64,linux/arm64
+          push: false
 
       - name: Build amd64 smoke-test image
         shell: bash
@@ -88,32 +84,100 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/k8s
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
-      - name: Validate release tag
+      - name: Resolve release tags
+        id: release
         shell: bash
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
+
           version_pattern='^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z][0-9A-Za-z.-]*)?$'
+          stable_pattern='^v[0-9]+\.[0-9]+\.[0-9]+$'
+
           if ! [[ "${RELEASE_TAG}" =~ ${version_pattern} ]]; then
             echo "::error::release tag must match ${version_pattern}: ${RELEASE_TAG}"
             exit 1
           fi
 
-      - name: Publish container image
-        uses: sentenz/actions/container-image@5c5271be112f7544262538c2b7ee6701efc9921f # sentenz/actions#57
+          publish_latest=false
+          if [[ "${RELEASE_TAG}" =~ ${stable_pattern} ]]; then
+            publish_latest=true
+          fi
+
+          {
+            echo "version=${RELEASE_TAG}"
+            echo "publish_latest=${publish_latest}"
+            echo "tags<<EOF"
+            echo "${IMAGE_NAME}:${RELEASE_TAG}"
+            if [[ "${publish_latest}" == true ]]; then
+              echo "${IMAGE_NAME}:latest"
+            fi
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
-          operation: publish
-          version: ${{ github.event.release.tag_name }}
-          publish-latest: auto
-          immutable: true
-          image-name: k8s
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Protect immutable release tag
+        shell: bash
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          version_image="${IMAGE_NAME}:${VERSION}"
+          if docker buildx imagetools inspect "${version_image}" >/dev/null 2>&1; then
+            echo "::error::refusing to overwrite existing immutable tag: ${version_image}"
+            exit 1
+          fi
+
+      - name: Build and publish container image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
           file: container/k8s/Dockerfile
           platforms: linux/amd64,linux/arm64
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          push: true
+          tags: ${{ steps.release.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=Kubernetes toolchain
+            org.opencontainers.image.description=Verified kubectl, Kustomize, kind, and Helm toolchain
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.release.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=Apache-2.0
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}
+          cache-to: type=gha,mode=max,scope=${{ env.IMAGE_NAME }}
+
+      - name: Verify published image
+        shell: bash
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          PUBLISH_LATEST: ${{ steps.release.outputs.publish_latest }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "${IMAGE_NAME}:${VERSION}"
+          if [[ "${PUBLISH_LATEST}" == true ]]; then
+            docker buildx imagetools inspect "${IMAGE_NAME}:latest"
+          fi

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -13,7 +13,7 @@ on:
       - published
 
 concurrency:
-  group: container-${{ github.workflow }}-${{ github.ref }}
+  group: container-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.release.tag_name || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
@@ -31,19 +31,54 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Validate container image
-        uses: sentenz/actions/container-image@5c5271be112f7544262538c2b7ee6701efc9921f # PR sentenz/actions#57
+      - name: Validate installer syntax
+        shell: bash
+        run: bash -n scripts/bootstrap.sh
+
+      - name: Validate multi-platform container image
+        uses: sentenz/actions/container-image@5c5271be112f7544262538c2b7ee6701efc9921f # sentenz/actions#57
         with:
           operation: build
           version: sha-${{ github.sha }}
           image-name: k8s
           file: container/k8s/Dockerfile
           platforms: linux/amd64,linux/arm64
-          build-args: |
-            KUBECTL_VERSION=v1.36.1
-            KUSTOMIZE_VERSION=v5.8.1
-            KIND_VERSION=v0.32.0
-            HELM_VERSION=v4.2.2
+
+      - name: Build amd64 smoke-test image
+        shell: bash
+        env:
+          TEST_IMAGE: local/k8s:${{ github.sha }}
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --file container/k8s/Dockerfile \
+            --platform linux/amd64 \
+            --load \
+            --tag "${TEST_IMAGE}" \
+            .
+
+      - name: Smoke test toolchain
+        shell: bash
+        env:
+          TEST_IMAGE: local/k8s:${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          expected_kubectl="$(docker image inspect --format '{{ index .Config.Labels "io.k8s.tools.kubectl.version" }}' "${TEST_IMAGE}")"
+          expected_kustomize="$(docker image inspect --format '{{ index .Config.Labels "io.k8s.tools.kustomize.version" }}' "${TEST_IMAGE}")"
+          expected_kind="$(docker image inspect --format '{{ index .Config.Labels "io.k8s.tools.kind.version" }}' "${TEST_IMAGE}")"
+          expected_helm="$(docker image inspect --format '{{ index .Config.Labels "io.k8s.tools.helm.version" }}' "${TEST_IMAGE}")"
+
+          kubectl_output="$(docker run --rm "${TEST_IMAGE}" kubectl version --client=true --output=yaml)"
+          kustomize_output="$(docker run --rm "${TEST_IMAGE}" kustomize version)"
+          kind_output="$(docker run --rm "${TEST_IMAGE}" kind version)"
+          helm_output="$(docker run --rm "${TEST_IMAGE}" helm version --short)"
+
+          printf '%s\n' "${kubectl_output}" "${kustomize_output}" "${kind_output}" "${helm_output}"
+          grep -F -- "${expected_kubectl}" <<< "${kubectl_output}"
+          grep -F -- "${expected_kustomize#v}" <<< "${kustomize_output}"
+          grep -F -- "${expected_kind#v}" <<< "${kind_output}"
+          grep -F -- "${expected_helm}" <<< "${helm_output}"
 
   publish:
     name: Publish Kubernetes Toolchain Image
@@ -59,8 +94,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Validate release tag
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          version_pattern='^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z][0-9A-Za-z.-]*)?$'
+          if ! [[ "${RELEASE_TAG}" =~ ${version_pattern} ]]; then
+            echo "::error::release tag must match ${version_pattern}: ${RELEASE_TAG}"
+            exit 1
+          fi
+
       - name: Publish container image
-        uses: sentenz/actions/container-image@5c5271be112f7544262538c2b7ee6701efc9921f # PR sentenz/actions#57
+        uses: sentenz/actions/container-image@5c5271be112f7544262538c2b7ee6701efc9921f # sentenz/actions#57
         with:
           operation: publish
           version: ${{ github.event.release.tag_name }}
@@ -70,8 +117,3 @@ jobs:
           file: container/k8s/Dockerfile
           platforms: linux/amd64,linux/arm64
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          build-args: |
-            KUBECTL_VERSION=v1.36.1
-            KUSTOMIZE_VERSION=v5.8.1
-            KIND_VERSION=v0.32.0
-            HELM_VERSION=v4.2.2

--- a/container/k8s/Dockerfile
+++ b/container/k8s/Dockerfile
@@ -35,15 +35,10 @@ ARG KUBECTL_VERSION=v1.36.1
 ARG KUSTOMIZE_VERSION=v5.8.1
 ARG KIND_VERSION=v0.32.0
 ARG HELM_VERSION=v4.2.2
-ARG IMAGE_VERSION=dev
-ARG VCS_REF=unknown
 
 LABEL org.opencontainers.image.title="Kubernetes toolchain" \
       org.opencontainers.image.description="Verified kubectl, Kustomize, kind, and Helm toolchain for local Kubernetes workflows" \
-      org.opencontainers.image.url="https://github.com/sentenz/template-k8s" \
       org.opencontainers.image.source="https://github.com/sentenz/template-k8s" \
-      org.opencontainers.image.version="${IMAGE_VERSION}" \
-      org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.licenses="Apache-2.0" \
       io.k8s.tools.kubectl.version="${KUBECTL_VERSION}" \
       io.k8s.tools.kustomize.version="${KUSTOMIZE_VERSION}" \

--- a/container/k8s/Dockerfile
+++ b/container/k8s/Dockerfile
@@ -35,10 +35,15 @@ ARG KUBECTL_VERSION=v1.36.1
 ARG KUSTOMIZE_VERSION=v5.8.1
 ARG KIND_VERSION=v0.32.0
 ARG HELM_VERSION=v4.2.2
+ARG IMAGE_VERSION=dev
+ARG VCS_REF=unknown
 
 LABEL org.opencontainers.image.title="Kubernetes toolchain" \
       org.opencontainers.image.description="Verified kubectl, Kustomize, kind, and Helm toolchain for local Kubernetes workflows" \
+      org.opencontainers.image.url="https://github.com/sentenz/template-k8s" \
       org.opencontainers.image.source="https://github.com/sentenz/template-k8s" \
+      org.opencontainers.image.version="${IMAGE_VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.licenses="Apache-2.0" \
       io.k8s.tools.kubectl.version="${KUBECTL_VERSION}" \
       io.k8s.tools.kustomize.version="${KUSTOMIZE_VERSION}" \


### PR DESCRIPTION
## Summary

- reduce `.github/workflows/container.yml` to pull-request validation and GitHub Release publication
- remove manual operation, image-version, promotion, and latest-policy inputs from the repository workflow
- publish container images only from `release.published`
- derive the published image version directly from `${{ github.event.release.tag_name }}`
- delegate Buildx, GHCR authentication, immutable-tag protection, provenance, SBOM, metadata, and registry verification to `sentenz/actions/container-image`

## Lifecycle

- pull requests run a multi-platform build without publishing
- published GitHub Releases build and publish `ghcr.io/sentenz/k8s:<release-tag>`
- stable release tags may update `latest` according to the shared action's `publish-latest: auto` policy
- existing release image tags cannot be overwritten

## Result

The workflow is 77 lines and changes only `.github/workflows/container.yml`. Repository release tags are now the authoritative container-image versions; there is no independent image-version cycle.

## Dependency

This PR is pinned to commit `5c5271be112f7544262538c2b7ee6701efc9921f` from sentenz/actions#57.

## Validation

- parsed the workflow as YAML
- confirmed the branch differs from `main` only in `.github/workflows/container.yml`
- validated the release publication contract uses `version: ${{ github.event.release.tag_name }}`

Closes #49