### PR TITLE
ci: add container image build and release publishing

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,10 +8,13 @@ on:
       - container/k8s/**
       - scripts/bootstrap.sh
       - .github/workflows/container.yml
+  release:
+    types:
+      - published
 
 concurrency:
   group: container-image-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -19,6 +22,7 @@ permissions:
 jobs:
   build:
     name: Build container image
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -36,3 +40,29 @@ jobs:
           image-name: k8s
           platforms: linux/amd64,linux/arm64
           push: false
+
+  publish:
+    name: Publish container image
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+
+      - name: Build and publish container image
+        uses: sentenz/actions/container-image@edd5e1e574e3eaa1254fbd19f4d2f0a5854c574d # 1.2.1
+        with:
+          version: ${{ github.event.release.tag_name }}
+          context: .
+          file: container/k8s/Dockerfile
+          image-name: k8s
+          platforms: linux/amd64,linux/arm64
+          push: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   build:
-    name: Build container image
+    name: Build Container Image
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -31,7 +31,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build container image
+      - name: Build Container Image
         uses: sentenz/actions/container-image@edd5e1e574e3eaa1254fbd19f4d2f0a5854c574d # 1.2.1
         with:
           version: pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
@@ -42,7 +42,7 @@ jobs:
           push: false
 
   publish:
-    name: Publish container image
+    name: Publish Container Image
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -56,7 +56,7 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
           persist-credentials: false
 
-      - name: Build and publish container image
+      - name: Publish Container Image
         uses: sentenz/actions/container-image@edd5e1e574e3eaa1254fbd19f4d2f0a5854c574d # 1.2.1
         with:
           version: ${{ github.event.release.tag_name }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Container Image
+
+on:
+  pull_request:
+    paths:
+      - container/k8s/**
+      - scripts/bootstrap.sh
+      - .github/workflows/container.yml
+
+concurrency:
+  group: container-image-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build container image
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Build container image
+        uses: sentenz/actions/container-image@edd5e1e574e3eaa1254fbd19f4d2f0a5854c574d # 1.2.1
+        with:
+          version: pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          context: .
+          file: container/k8s/Dockerfile
+          image-name: k8s
+          platforms: linux/amd64,linux/arm64
+          push: false

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: write
       issues: write
+      packages: write
       pull-requests: write
       id-token: write
     steps:
@@ -36,6 +37,13 @@ jobs:
             @semantic-release/changelog@^6
             @semantic-release/git@^10
             conventional-changelog-conventionalcommits@9.3.1
+
+      - name: Checkout release tag
+        if: steps.release.outputs.new-release-published == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ steps.release.outputs.new-release-git-tag }}
+          persist-credentials: false
 
       - name: Run SBOM Generation (CycloneDX)
         if: steps.release.outputs.new-release-published == 'true'
@@ -59,9 +67,21 @@ jobs:
         if: steps.release.outputs.new-release-published == 'true'
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          tag_name: ${{ steps.release.outputs.new-release-version }}
+          tag_name: ${{ steps.release.outputs.new-release-git-tag }}
           files: |
             sbom.cdx.json
             sbom.spdx.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish container image
+        if: steps.release.outputs.new-release-published == 'true'
+        uses: sentenz/actions/container-image@edd5e1e574e3eaa1254fbd19f4d2f0a5854c574d # 1.2.1
+        with:
+          version: ${{ steps.release.outputs.new-release-git-tag }}
+          context: .
+          file: container/k8s/Dockerfile
+          image-name: k8s
+          platforms: linux/amd64,linux/arm64
+          push: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -17,7 +17,6 @@ jobs:
     permissions:
       contents: write
       issues: write
-      packages: write
       pull-requests: write
       id-token: write
     steps:
@@ -37,13 +36,6 @@ jobs:
             @semantic-release/changelog@^6
             @semantic-release/git@^10
             conventional-changelog-conventionalcommits@9.3.1
-
-      - name: Checkout release tag
-        if: steps.release.outputs.new-release-published == 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ steps.release.outputs.new-release-git-tag }}
-          persist-credentials: false
 
       - name: Run SBOM Generation (CycloneDX)
         if: steps.release.outputs.new-release-published == 'true'
@@ -67,21 +59,9 @@ jobs:
         if: steps.release.outputs.new-release-published == 'true'
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          tag_name: ${{ steps.release.outputs.new-release-git-tag }}
+          tag_name: ${{ steps.release.outputs.new-release-version }}
           files: |
             sbom.cdx.json
             sbom.spdx.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and publish container image
-        if: steps.release.outputs.new-release-published == 'true'
-        uses: sentenz/actions/container-image@edd5e1e574e3eaa1254fbd19f4d2f0a5854c574d # 1.2.1
-        with:
-          version: ${{ steps.release.outputs.new-release-git-tag }}
-          context: .
-          file: container/k8s/Dockerfile
-          image-name: k8s
-          platforms: linux/amd64,linux/arm64
-          push: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- add a pull-request workflow that builds `container/k8s/Dockerfile` without publishing
- add a release publishing job to the same `container.yml` workflow
- use `${{ github.event.release.tag_name }}` as the immutable image version
- publish `ghcr.io/sentenz/k8s:<tag>` and `ghcr.io/sentenz/k8s:latest` for `linux/amd64` and `linux/arm64`
- leave the Semantic Release workflow unchanged

## Events

- `pull_request`: build only with `push: false`
- `release` with type `published`: build and push with the release Git tag

## Validation

- reviewed the workflow diff against the `sentenz/actions/container-image` input contract
- pinned the composite action to `sentenz/actions` release `1.2.1`
- the pull-request workflow exercises the multi-platform Docker build without registry publishing
