### PR TITLE
ci: publish container through reusable workflow

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,6 +8,16 @@ on:
       - container/k8s/**
       - scripts/bootstrap.sh
       - .github/workflows/container.yml
+  workflow_call:
+    inputs:
+      publish:
+        description: Publish the container image to GHCR
+        required: true
+        type: boolean
+      version:
+        description: Container image version and Git tag to publish
+        required: true
+        type: string
 
 concurrency:
   group: container-image-${{ github.workflow }}-${{ github.ref }}
@@ -37,3 +47,29 @@ jobs:
           image-name: k8s
           platforms: linux/amd64,linux/arm64
           push: false
+
+  publish:
+    name: Publish Container Image
+    if: inputs.publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.version }}
+          persist-credentials: false
+
+      - name: Publish Container Image
+        uses: sentenz/actions/container-image@edd5e1e574e3eaa1254fbd19f4d2f0a5854c574d # 1.2.1
+        with:
+          version: ${{ inputs.version }}
+          context: .
+          file: container/k8s/Dockerfile
+          image-name: k8s
+          platforms: linux/amd64,linux/arm64
+          push: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,9 +8,6 @@ on:
       - container/k8s/**
       - scripts/bootstrap.sh
       - .github/workflows/container.yml
-  release:
-    types:
-      - published
 
 concurrency:
   group: container-image-${{ github.workflow }}-${{ github.ref }}
@@ -40,29 +37,3 @@ jobs:
           image-name: k8s
           platforms: linux/amd64,linux/arm64
           push: false
-
-  publish:
-    name: Publish Container Image
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout release tag
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.release.tag_name }}
-          persist-credentials: false
-
-      - name: Publish Container Image
-        uses: sentenz/actions/container-image@edd5e1e574e3eaa1254fbd19f4d2f0a5854c574d # 1.2.1
-        with:
-          version: ${{ github.event.release.tag_name }}
-          context: .
-          file: container/k8s/Dockerfile
-          image-name: k8s
-          platforms: linux/amd64,linux/arm64
-          push: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -14,6 +14,9 @@ jobs:
   semantic-release:
     name: Semantic-Release Action
     runs-on: ubuntu-latest
+    outputs:
+      new-release-published: ${{ steps.release.outputs.new-release-published }}
+      new-release-version: ${{ steps.release.outputs.new-release-version }}
     permissions:
       contents: write
       issues: write
@@ -65,3 +68,31 @@ jobs:
             sbom.spdx.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-container:
+    name: Publish Container Image
+    needs:
+      - semantic-release
+    if: needs.semantic-release.outputs.new-release-published == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.semantic-release.outputs.new-release-version }}
+          persist-credentials: false
+
+      - name: Publish Container Image
+        uses: sentenz/actions/container-image@edd5e1e574e3eaa1254fbd19f4d2f0a5854c574d # 1.2.1
+        with:
+          version: ${{ needs.semantic-release.outputs.new-release-version }}
+          context: .
+          file: container/k8s/Dockerfile
+          image-name: k8s
+          platforms: linux/amd64,linux/arm64
+          push: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -74,25 +74,10 @@ jobs:
     needs:
       - semantic-release
     if: needs.semantic-release.outputs.new-release-published == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
-    steps:
-      - name: Checkout release tag
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ needs.semantic-release.outputs.new-release-version }}
-          persist-credentials: false
-
-      - name: Publish Container Image
-        uses: sentenz/actions/container-image@edd5e1e574e3eaa1254fbd19f4d2f0a5854c574d # 1.2.1
-        with:
-          version: ${{ needs.semantic-release.outputs.new-release-version }}
-          context: .
-          file: container/k8s/Dockerfile
-          image-name: k8s
-          platforms: linux/amd64,linux/arm64
-          push: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/container.yml
+    with:
+      publish: true
+      version: ${{ needs.semantic-release.outputs.new-release-version }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -73,7 +73,7 @@ jobs:
     name: Publish Container Image
     needs:
       - semantic-release
-    if: needs.semantic-release.outputs.new-release-published == 'true'
+    if: always() && needs.semantic-release.outputs.new-release-published == 'true'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

- expose the Semantic Release publication status and version as job outputs
- make `.github/workflows/container.yml` reusable through `workflow_call`
- keep both container build validation and image publication jobs in `container.yml`
- invoke the reusable container workflow after Semantic Release publishes a new version
- grant `packages: write` only to the reusable workflow call and publication job

## Root cause

The original container workflow listened for `release.published`. The GitHub release is created by Semantic Release using the workflow-provided `GITHUB_TOKEN`; GitHub suppresses ordinary workflow events generated by that token to prevent recursive workflow execution. Consequently, the release event did not start the container workflow.

## Design

`semantic-release.yml` calls `container.yml` directly as a reusable workflow when `new-release-published == 'true'` and passes the released version as an input.

`container.yml` remains the single source of truth:

- pull requests run `build` with `push: false`
- reusable workflow calls run `publish` with `push: true`
- publication checks out the released tag and publishes `ghcr.io/sentenz/k8s:<version>` and `ghcr.io/sentenz/k8s:latest`

## Validation

- verified the pinned Semantic Release action exposes `new-release-published` and `new-release-version`
- verified same-repository reusable workflows receive `GITHUB_TOKEN` automatically
- verified the caller grants `contents: read` and `packages: write`, which the called workflow cannot elevate
- verified the pinned container action accepts the configured inputs
- parsed both modified workflow files as YAML 1.2
- confirmed only the two intended workflow files differ from `main`
- confirmed the PR `Container Image` workflow passed: `Build Container Image` succeeded and `Publish Container Image` was skipped
