### PR TITLE
refine selectable Kubernetes tool installation

### DIFF
--- a/container/k8s/Dockerfile
+++ b/container/k8s/Dockerfile
@@ -7,6 +7,7 @@ ARG KUBECTL_VERSION=v1.36.3
 ARG KUSTOMIZE_VERSION=v5.8.1
 ARG KIND_VERSION=v0.32.0
 ARG HELM_VERSION=v4.2.3
+ARG TOOLS=kubectl,kustomize,kind,helm
 ARG TARGETOS=linux
 ARG TARGETARCH
 
@@ -27,7 +28,7 @@ RUN INSTALL_DIR=/opt/k8s/bin \
     HELM_VERSION="${HELM_VERSION}" \
     TARGETOS="${TARGETOS}" \
     TARGETARCH="${TARGETARCH}" \
-    /usr/local/bin/bootstrap.sh
+    /usr/local/bin/bootstrap.sh --tool "${TOOLS}"
 
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
@@ -35,11 +36,13 @@ ARG KUBECTL_VERSION=v1.36.3
 ARG KUSTOMIZE_VERSION=v5.8.1
 ARG KIND_VERSION=v0.32.0
 ARG HELM_VERSION=v4.2.3
+ARG TOOLS=kubectl,kustomize,kind,helm
 
 LABEL org.opencontainers.image.title="Kubernetes toolchain" \
-      org.opencontainers.image.description="Verified kubectl, Kustomize, kind, and Helm toolchain for local Kubernetes workflows" \
+      org.opencontainers.image.description="Verified Kubernetes command-line toolchain for local workflows" \
       org.opencontainers.image.source="https://github.com/sentenz/template-k8s" \
       org.opencontainers.image.licenses="Apache-2.0" \
+      io.k8s.tools.selection="${TOOLS}" \
       io.k8s.tools.kubectl.version="${KUBECTL_VERSION}" \
       io.k8s.tools.kustomize.version="${KUSTOMIZE_VERSION}" \
       io.k8s.tools.kind.version="${KIND_VERSION}" \

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -100,6 +100,7 @@ parse_args() {
     case "$1" in
       -t|--tool)
         (( $# > 1 )) || fail "$1 requires a tool name"
+        [[ -n "$2" ]] || fail "$1 requires a tool name"
         selected+=("$2")
         shift 2
         ;;

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -20,6 +20,7 @@ readonly DEFAULT_KUSTOMIZE_VERSION="v5.8.1"
 readonly DEFAULT_KIND_VERSION="v0.32.0"
 readonly DEFAULT_HELM_VERSION="v4.2.3"
 readonly DEFAULT_TOOLS="kubectl,kustomize,kind,helm"
+readonly SUPPORTED_TOOLS=(kubectl kustomize kind helm)
 
 readonly KUBECTL_VERSION="${KUBECTL_VERSION:-${DEFAULT_KUBECTL_VERSION}}"
 readonly KUSTOMIZE_VERSION="${KUSTOMIZE_VERSION:-${DEFAULT_KUSTOMIZE_VERSION}}"
@@ -29,6 +30,7 @@ readonly TARGETOS="${TARGETOS:-$(uname -s | tr '[:upper:]' '[:lower:]')}"
 readonly TARGETARCH="${TARGETARCH:-$(uname -m)}"
 TOOLS="${TOOLS:-${DEFAULT_TOOLS}}"
 INSTALL_DIR="${INSTALL_DIR:-}"
+
 readonly CURL_OPTIONS=(
   --connect-timeout 15
   --fail
@@ -62,10 +64,12 @@ cleanup() {
     rm -rf -- "${TMP_DIR}"
   fi
 }
+
 trap cleanup EXIT INT TERM HUP
 
 usage() {
   printf 'Usage: %s [OPTIONS] [TOOL...]\n' "${0##*/}"
+
   cat <<'EOF_USAGE'
 
 Install Kubernetes command-line tools. Without a selection, all supported tools
@@ -90,7 +94,18 @@ EOF_USAGE
 }
 
 list_tools() {
-  printf '%s\n' kubectl kustomize kind helm
+  printf '%s\n' "${SUPPORTED_TOOLS[@]}"
+}
+
+is_supported_tool() {
+  local candidate="$1"
+  local supported
+
+  for supported in "${SUPPORTED_TOOLS[@]}"; do
+    [[ "${candidate}" == "${supported}" ]] && return 0
+  done
+
+  return 1
 }
 
 parse_args() {
@@ -138,7 +153,8 @@ parse_args() {
 }
 
 require_command() {
-  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+  command -v "$1" >/dev/null 2>&1 \
+    || fail "required command not found: $1"
 }
 
 resolve_install_dir() {
@@ -167,24 +183,28 @@ resolve_requested_tools() {
   local -a requested=()
   declare -A seen=()
 
+  REQUESTED_TOOLS=()
+
   normalized="${TOOLS//,/ }"
   read -r -a requested <<< "${normalized}"
-  (( ${#requested[@]} > 0 )) || fail "select at least one tool"
+
+  (( ${#requested[@]} > 0 )) \
+    || fail "select at least one tool"
 
   for tool in "${requested[@]}"; do
     [[ -n "${tool}" ]] || continue
-    [[ -z "${seen[${tool}]:-}" ]] || continue
 
-    case "${tool}" in
-      kubectl|kustomize|kind|helm) ;;
-      *) fail "unsupported tool: ${tool}" ;;
-    esac
+    is_supported_tool "${tool}" \
+      || fail "unsupported tool: ${tool}"
+
+    [[ -z "${seen[${tool}]:-}" ]] || continue
 
     seen["${tool}"]=1
     REQUESTED_TOOLS+=("${tool}")
   done
 
-  (( ${#REQUESTED_TOOLS[@]} > 0 )) || fail "select at least one tool"
+  (( ${#REQUESTED_TOOLS[@]} > 0 )) \
+    || fail "select at least one tool"
 }
 
 require_selected_commands() {
@@ -199,7 +219,9 @@ require_selected_commands() {
 
   for tool in "${REQUESTED_TOOLS[@]}"; do
     case "${tool}" in
-      kustomize|helm) requires_tar=true ;;
+      kustomize|helm)
+        requires_tar=true
+        ;;
     esac
   done
 
@@ -213,30 +235,51 @@ validate_selected_versions() {
 
   for tool in "${REQUESTED_TOOLS[@]}"; do
     case "${tool}" in
-      kubectl) validate_version kubectl "${KUBECTL_VERSION}" ;;
-      kustomize) validate_version kustomize "${KUSTOMIZE_VERSION}" ;;
-      kind) validate_version kind "${KIND_VERSION}" ;;
-      helm) validate_version helm "${HELM_VERSION}" ;;
+      kubectl)
+        validate_version kubectl "${KUBECTL_VERSION}"
+        ;;
+      kustomize)
+        validate_version kustomize "${KUSTOMIZE_VERSION}"
+        ;;
+      kind)
+        validate_version kind "${KIND_VERSION}"
+        ;;
+      helm)
+        validate_version helm "${HELM_VERSION}"
+        ;;
     esac
   done
 }
 
 normalize_platform() {
   case "${TARGETOS}" in
-    linux) OS=linux ;;
-    *) fail "unsupported target operating system: ${TARGETOS}" ;;
+    linux)
+      OS=linux
+      ;;
+    *)
+      fail "unsupported target operating system: ${TARGETOS}"
+      ;;
   esac
 
   case "${TARGETARCH}" in
-    amd64|x86_64) ARCH=amd64 ;;
-    arm64|aarch64) ARCH=arm64 ;;
-    *) fail "unsupported target architecture: ${TARGETARCH}" ;;
+    amd64|x86_64)
+      ARCH=amd64
+      ;;
+    arm64|aarch64)
+      ARCH=arm64
+      ;;
+    *)
+      fail "unsupported target architecture: ${TARGETARCH}"
+      ;;
   esac
 }
 
 validate_install_dir() {
-  [[ "${INSTALL_DIR}" == /* ]] || fail "INSTALL_DIR must be an absolute path"
+  [[ "${INSTALL_DIR}" == /* ]] \
+    || fail "INSTALL_DIR must be an absolute path"
+
   mkdir -p -- "${INSTALL_DIR}"
+
   [[ -d "${INSTALL_DIR}" && -w "${INSTALL_DIR}" ]] \
     || fail "INSTALL_DIR is not writable: ${INSTALL_DIR}"
 }
@@ -247,7 +290,9 @@ download() {
 
   log "downloading ${url}"
   curl "${CURL_OPTIONS[@]}" --output "${output}" -- "${url}"
-  [[ -s "${output}" ]] || fail "downloaded file is empty: ${url}"
+
+  [[ -s "${output}" ]] \
+    || fail "downloaded file is empty: ${url}"
 }
 
 read_sha256() {
@@ -256,7 +301,14 @@ read_sha256() {
   local checksum=""
 
   if [[ -n "${asset_name}" ]]; then
-    checksum="$({ awk -v name="${asset_name}" '$2 == name || $2 == "*" name {print $1; exit}' "${checksum_file}"; } || true)"
+    checksum="$(
+      {
+        awk -v name="${asset_name}" \
+          '$2 == name || $2 == "*" name {print $1; exit}' \
+          "${checksum_file}"
+      } || true
+    )"
+
     [[ -n "${checksum}" ]] \
       || fail "checksum manifest does not contain asset: ${asset_name}"
   else
@@ -265,6 +317,7 @@ read_sha256() {
 
   [[ "${checksum}" =~ ^[0-9A-Fa-f]{64}$ ]] \
     || fail "invalid SHA-256 checksum in ${checksum_file}"
+
   printf '%s\n' "${checksum,,}"
 }
 
@@ -274,15 +327,19 @@ verify_sha256() {
   local actual
 
   actual="$(sha256sum "${file}" | awk '{print $1}')"
+
   [[ "${actual}" == "${expected}" ]] \
-    || fail "checksum mismatch for $(basename "${file}"): expected ${expected}, got ${actual}"
+    || fail \
+      "checksum mismatch for $(basename "${file}"): expected ${expected}, got ${actual}"
 }
 
 install_binary() {
   local source="$1"
   local name="$2"
 
-  [[ -f "${source}" ]] || fail "binary not found after extraction: ${source}"
+  [[ -f "${source}" ]] \
+    || fail "binary not found after extraction: ${source}"
+
   install -m 0755 -- "${source}" "${INSTALL_DIR}/${name}"
   log "installed ${name} to ${INSTALL_DIR}/${name}"
 }
@@ -295,13 +352,17 @@ install_kubectl() {
   checksum_file="${TMP_DIR}/${asset}.sha256"
 
   download "${base_url}/${asset}" "${TMP_DIR}/${asset}"
+
   if [[ -n "${KUBECTL_SHA256:-}" ]]; then
     expected="${KUBECTL_SHA256,,}"
   else
     download "${base_url}/${asset}.sha256" "${checksum_file}"
     expected="$(read_sha256 "${checksum_file}")"
   fi
-  [[ "${expected}" =~ ^[0-9a-f]{64}$ ]] || fail "invalid KUBECTL_SHA256"
+
+  [[ "${expected}" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "invalid KUBECTL_SHA256"
+
   verify_sha256 "${TMP_DIR}/${asset}" "${expected}"
   install_binary "${TMP_DIR}/${asset}" kubectl
 }
@@ -314,13 +375,17 @@ install_kind() {
   checksum_file="${TMP_DIR}/${asset}.sha256sum"
 
   download "${base_url}/${asset}" "${TMP_DIR}/${asset}"
+
   if [[ -n "${KIND_SHA256:-}" ]]; then
     expected="${KIND_SHA256,,}"
   else
     download "${base_url}/${asset}.sha256sum" "${checksum_file}"
     expected="$(read_sha256 "${checksum_file}" "${asset}")"
   fi
-  [[ "${expected}" =~ ^[0-9a-f]{64}$ ]] || fail "invalid KIND_SHA256"
+
+  [[ "${expected}" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "invalid KIND_SHA256"
+
   verify_sha256 "${TMP_DIR}/${asset}" "${expected}"
   install_binary "${TMP_DIR}/${asset}" kind
 }
@@ -335,17 +400,27 @@ install_kustomize() {
   extract_dir="${TMP_DIR}/kustomize"
 
   download "${base_url}/${asset}" "${archive}"
+
   if [[ -n "${KUSTOMIZE_SHA256:-}" ]]; then
     expected="${KUSTOMIZE_SHA256,,}"
   else
     download "${base_url}/checksums.txt" "${checksum_file}"
     expected="$(read_sha256 "${checksum_file}" "${asset}")"
   fi
-  [[ "${expected}" =~ ^[0-9a-f]{64}$ ]] || fail "invalid KUSTOMIZE_SHA256"
+
+  [[ "${expected}" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "invalid KUSTOMIZE_SHA256"
+
   verify_sha256 "${archive}" "${expected}"
 
   mkdir -p -- "${extract_dir}"
-  tar --extract --gzip --file "${archive}" --directory "${extract_dir}" --no-same-owner
+  tar \
+    --extract \
+    --gzip \
+    --file "${archive}" \
+    --directory "${extract_dir}" \
+    --no-same-owner
+
   install_binary "${extract_dir}/kustomize" kustomize
 }
 
@@ -360,17 +435,27 @@ install_helm() {
   extract_dir="${TMP_DIR}/helm"
 
   download "${base_url}/${asset}" "${archive}"
+
   if [[ -n "${HELM_SHA256:-}" ]]; then
     expected="${HELM_SHA256,,}"
   else
     download "${base_url}/${asset}.sha256sum" "${checksum_file}"
     expected="$(read_sha256 "${checksum_file}" "${asset}")"
   fi
-  [[ "${expected}" =~ ^[0-9a-f]{64}$ ]] || fail "invalid HELM_SHA256"
+
+  [[ "${expected}" =~ ^[0-9a-f]{64}$ ]] \
+    || fail "invalid HELM_SHA256"
+
   verify_sha256 "${archive}" "${expected}"
 
   mkdir -p -- "${extract_dir}"
-  tar --extract --gzip --file "${archive}" --directory "${extract_dir}" --no-same-owner
+  tar \
+    --extract \
+    --gzip \
+    --file "${archive}" \
+    --directory "${extract_dir}" \
+    --no-same-owner
+
   install_binary "${extract_dir}/${OS}-${ARCH}/helm" helm
 }
 
@@ -379,10 +464,18 @@ install_requested_tools() {
 
   for tool in "${REQUESTED_TOOLS[@]}"; do
     case "${tool}" in
-      kubectl) install_kubectl ;;
-      kustomize) install_kustomize ;;
-      kind) install_kind ;;
-      helm) install_helm ;;
+      kubectl)
+        install_kubectl
+        ;;
+      kustomize)
+        install_kustomize
+        ;;
+      kind)
+        install_kind
+        ;;
+      helm)
+        install_helm
+        ;;
     esac
   done
 }
@@ -397,7 +490,9 @@ main() {
   validate_install_dir
 
   TMP_DIR="$(mktemp -d)"
-  [[ -d "${TMP_DIR}" ]] || fail "unable to create temporary directory"
+
+  [[ -d "${TMP_DIR}" ]] \
+    || fail "unable to create temporary directory"
 
   install_requested_tools
 }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
+#
+# Usage:
+#   ./scripts/bootstrap.sh [OPTIONS] [TOOL...]
+#
+# Examples:
+#   ./scripts/bootstrap.sh
+#   ./scripts/bootstrap.sh kubectl helm
+#   ./scripts/bootstrap.sh --tool kubectl --tool kind
+#   TOOLS=kubectl,kustomize ./scripts/bootstrap.sh
+#
+# Run ./scripts/bootstrap.sh --help for all options.
 
 set -Eeuo pipefail
 umask 022

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,6 +8,7 @@ readonly DEFAULT_KUBECTL_VERSION="v1.36.3"
 readonly DEFAULT_KUSTOMIZE_VERSION="v5.8.1"
 readonly DEFAULT_KIND_VERSION="v0.32.0"
 readonly DEFAULT_HELM_VERSION="v4.2.3"
+readonly DEFAULT_TOOLS="kubectl,kustomize,kind,helm"
 
 readonly KUBECTL_VERSION="${KUBECTL_VERSION:-${DEFAULT_KUBECTL_VERSION}}"
 readonly KUSTOMIZE_VERSION="${KUSTOMIZE_VERSION:-${DEFAULT_KUSTOMIZE_VERSION}}"
@@ -15,20 +16,8 @@ readonly KIND_VERSION="${KIND_VERSION:-${DEFAULT_KIND_VERSION}}"
 readonly HELM_VERSION="${HELM_VERSION:-${DEFAULT_HELM_VERSION}}"
 readonly TARGETOS="${TARGETOS:-$(uname -s | tr '[:upper:]' '[:lower:]')}"
 readonly TARGETARCH="${TARGETARCH:-$(uname -m)}"
-readonly TOOLS="${TOOLS:-kubectl,kustomize,kind,helm}"
-readonly INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
-if [[ -z "${INSTALL_DIR+x}" ]]; then
-  if [[ -w /usr/local/bin ]]; then
-    INSTALL_DIR=/usr/local/bin
-  elif [[ -n "${HOME:-}" ]]; then
-    INSTALL_DIR="${HOME}/.local/bin"
-    export PATH="${INSTALL_DIR}:${PATH}"
-  else
-    printf '[bootstrap] error: unable to determine a writable install directory\n' >&2
-    exit 1
-  fi
-fi
-readonly INSTALL_DIR
+TOOLS="${TOOLS:-${DEFAULT_TOOLS}}"
+INSTALL_DIR="${INSTALL_DIR:-}"
 readonly CURL_OPTIONS=(
   --connect-timeout 15
   --fail
@@ -46,6 +35,7 @@ readonly CURL_OPTIONS=(
 TMP_DIR=""
 OS=""
 ARCH=""
+declare -a REQUESTED_TOOLS=()
 
 log() {
   printf '[bootstrap] %s\n' "$*" >&2
@@ -63,8 +53,93 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM HUP
 
+usage() {
+  printf 'Usage: %s [OPTIONS] [TOOL...]\n' "${0##*/}"
+  cat <<'EOF_USAGE'
+
+Install Kubernetes command-line tools. Without a selection, all supported tools
+are installed. Tool names may be supplied as separate arguments or as a
+comma-separated list.
+
+Options:
+  -t, --tool TOOL  Select a tool to install; may be repeated
+      --list-tools List supported tools and exit
+  -h, --help       Show this help and exit
+
+Environment:
+  TOOLS            Comma- or space-separated tools used when no CLI selection
+                   is supplied (default: kubectl,kustomize,kind,helm)
+  INSTALL_DIR      Absolute destination directory for installed binaries
+
+Examples:
+  ./scripts/bootstrap.sh kubectl helm
+  ./scripts/bootstrap.sh --tool kubectl --tool kind
+  TOOLS=kubectl,kustomize ./scripts/bootstrap.sh
+EOF_USAGE
+}
+
+list_tools() {
+  printf '%s\n' kubectl kustomize kind helm
+}
+
+parse_args() {
+  local -a selected=()
+
+  while (( $# > 0 )); do
+    case "$1" in
+      -t|--tool)
+        (( $# > 1 )) || fail "$1 requires a tool name"
+        selected+=("$2")
+        shift 2
+        ;;
+      --tool=*)
+        [[ -n "${1#*=}" ]] || fail "--tool requires a tool name"
+        selected+=("${1#*=}")
+        shift
+        ;;
+      --list-tools)
+        list_tools
+        exit 0
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      --)
+        shift
+        selected+=("$@")
+        break
+        ;;
+      -*)
+        fail "unknown option: $1"
+        ;;
+      *)
+        selected+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  if (( ${#selected[@]} > 0 )); then
+    TOOLS="${selected[*]}"
+  fi
+}
+
 require_command() {
   command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+resolve_install_dir() {
+  if [[ -z "${INSTALL_DIR}" ]]; then
+    if [[ -w /usr/local/bin ]]; then
+      INSTALL_DIR=/usr/local/bin
+    elif [[ -n "${HOME:-}" ]]; then
+      INSTALL_DIR="${HOME}/.local/bin"
+      export PATH="${INSTALL_DIR}:${PATH}"
+    else
+      fail "unable to determine a writable install directory"
+    fi
+  fi
 }
 
 validate_version() {
@@ -73,6 +148,65 @@ validate_version() {
 
   [[ "${version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z][0-9A-Za-z.-]*)?$ ]] \
     || fail "invalid ${tool} version: ${version}"
+}
+
+resolve_requested_tools() {
+  local normalized tool
+  local -a requested=()
+  declare -A seen=()
+
+  normalized="${TOOLS//,/ }"
+  read -r -a requested <<< "${normalized}"
+  (( ${#requested[@]} > 0 )) || fail "select at least one tool"
+
+  for tool in "${requested[@]}"; do
+    [[ -n "${tool}" ]] || continue
+    [[ -z "${seen[${tool}]:-}" ]] || continue
+
+    case "${tool}" in
+      kubectl|kustomize|kind|helm) ;;
+      *) fail "unsupported tool: ${tool}" ;;
+    esac
+
+    seen["${tool}"]=1
+    REQUESTED_TOOLS+=("${tool}")
+  done
+
+  (( ${#REQUESTED_TOOLS[@]} > 0 )) || fail "select at least one tool"
+}
+
+require_selected_commands() {
+  local tool
+  local requires_tar=false
+
+  require_command awk
+  require_command curl
+  require_command install
+  require_command mktemp
+  require_command sha256sum
+
+  for tool in "${REQUESTED_TOOLS[@]}"; do
+    case "${tool}" in
+      kustomize|helm) requires_tar=true ;;
+    esac
+  done
+
+  if [[ "${requires_tar}" == true ]]; then
+    require_command tar
+  fi
+}
+
+validate_selected_versions() {
+  local tool
+
+  for tool in "${REQUESTED_TOOLS[@]}"; do
+    case "${tool}" in
+      kubectl) validate_version kubectl "${KUBECTL_VERSION}" ;;
+      kustomize) validate_version kustomize "${KUSTOMIZE_VERSION}" ;;
+      kind) validate_version kind "${KIND_VERSION}" ;;
+      helm) validate_version helm "${HELM_VERSION}" ;;
+    esac
+  done
 }
 
 normalize_platform() {
@@ -229,41 +363,25 @@ install_helm() {
 }
 
 install_requested_tools() {
-  local normalized tool
-  local -a requested=()
-  declare -A seen=()
+  local tool
 
-  normalized="${TOOLS//,/ }"
-  read -r -a requested <<< "${normalized}"
-  (( ${#requested[@]} > 0 )) || fail "TOOLS must select at least one tool"
-
-  for tool in "${requested[@]}"; do
-    [[ -n "${tool}" ]] || continue
-    [[ -z "${seen[${tool}]:-}" ]] || continue
-    seen["${tool}"]=1
-
+  for tool in "${REQUESTED_TOOLS[@]}"; do
     case "${tool}" in
       kubectl) install_kubectl ;;
       kustomize) install_kustomize ;;
       kind) install_kind ;;
       helm) install_helm ;;
-      *) fail "unsupported tool in TOOLS: ${tool}" ;;
     esac
   done
 }
 
 main() {
-  require_command curl
-  require_command install
-  require_command mktemp
-  require_command sha256sum
-  require_command tar
-
-  validate_version kubectl "${KUBECTL_VERSION}"
-  validate_version kustomize "${KUSTOMIZE_VERSION}"
-  validate_version kind "${KIND_VERSION}"
-  validate_version helm "${HELM_VERSION}"
+  parse_args "$@"
+  resolve_requested_tools
+  require_selected_commands
+  validate_selected_versions
   normalize_platform
+  resolve_install_dir
   validate_install_dir
 
   TMP_DIR="$(mktemp -d)"


### PR DESCRIPTION
## Summary

- add positional and repeatable `--tool` selection for `kubectl`, `kustomize`, `kind`, and `helm`
- preserve `TOOLS` as the default environment-based selector, with CLI selections taking precedence
- add `--help` and `--list-tools` discovery commands
- document common invocation forms at the top of `scripts/bootstrap.sh`
- deduplicate selections and reject unsupported tool names before performing installation work
- validate versions and require archive tooling only for the selected tools
- defer install-directory resolution until an installation is actually requested and restore the intended writable-directory fallback
- expose the tool selection as a container `TOOLS` build argument
- invoke the refined bootstrap CLI explicitly from the installer stage
- record the selected tool set in container metadata and avoid describing selective images as containing every tool

## Impact

Running `./scripts/bootstrap.sh` or building the container without overrides remains backward compatible and installs the complete toolchain.

Targeted host installations can use:

```bash
./scripts/bootstrap.sh kubectl helm
./scripts/bootstrap.sh --tool kubectl --tool kind
TOOLS=kubectl,kustomize ./scripts/bootstrap.sh
```

Targeted container images can use:

```bash
docker build \
  --build-arg TOOLS=kubectl,helm \
  --file container/k8s/Dockerfile \
  .
```

The resulting image includes only the selected tool binaries and publishes the selection through `io.k8s.tools.selection`.

## Validation

- `bash -n scripts/bootstrap.sh`
- verified the source header matches the executable usage forms
- verified `--help` and `--list-tools`
- exercised mocked `kubectl` + `kind` installation
- verified CLI selection overrides `TOOLS`
- verified duplicate selections install once
- verified unrelated invalid version overrides do not block selected tools
- verified `tar` is not required or invoked for binary-only selections
- verified unsupported and missing tool arguments fail before downloads
- reviewed the Dockerfile stage-scoped arguments, bootstrap invocation, and OCI labels
- GitHub container workflow validates multi-architecture image builds for the updated Dockerfile