### PR TITLE
fix: allow Renovate to push update branches

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -13,7 +13,7 @@ jobs:
     name: Renovate Action
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       checks: read


### PR DESCRIPTION
## Summary

Grant the Renovate workflow write access to repository contents.

## Root cause

The workflow passed `GITHUB_TOKEN` to Renovate while declaring `contents: read`. Renovate could detect dependency updates, modify files, and create a local commit, but GitHub rejected the branch push with HTTP 403. Without a remote branch, Renovate could not open update pull requests, including the Traefik Helm chart update from `40.3.0` to `41.0.2`.

## Change

- change the Renovate job permission from `contents: read` to `contents: write`
- retain the existing pull-request, issue, check, and OIDC permissions

## Impact

Renovate can create and update `renovate/*` branches and subsequently open dependency update pull requests.

## Validation

- compared the branch against `main`
- confirmed the diff contains one workflow file with exactly one permission-line replacement
