### PR TITLE
fix(renovate): tighten dependency detection and token isolation

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -5,7 +5,6 @@ name: Renovate
 on:
   workflow_dispatch:
   schedule:
-    # Run weekly on Sundays at 4:00 AM UTC
     - cron: "0 4 * * 0"
 
 concurrency:
@@ -27,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Renovate
-        uses: sentenz/actions/renovate@edd5e1e574e3eaa1254fbd19f4d2f0a5854c574d # 1.2.1
+        uses: sentenz/actions/renovate@60efccb4fffbfbbe6db57c11f68d73462aa0957c # 1.2.2
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
           autodiscover: "false"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,22 +8,26 @@ on:
     # Run weekly on Sundays at 4:00 AM UTC
     - cron: "0 4 * * 0"
 
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
 jobs:
   renovate:
     name: Renovate Action
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      checks: read
-      id-token: write
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Run Renovate
         uses: sentenz/actions/renovate@edd5e1e574e3eaa1254fbd19f4d2f0a5854c574d # 1.2.1
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
-          autodiscover: "true"
+          autodiscover: "false"

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -41,7 +41,7 @@
         "**/action.{yml,yaml}"
       ],
       "matchStrings": [
-        "(?<depName>(?:(?:[A-Za-z0-9.-]+(?::[0-9]+)?/)?[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*)):(?<currentValue>v?\\d[0-9A-Za-z_.-]*)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
+        "(?<depName>(?:(?:[A-Za-z0-9.-]+(?::[0-9]+)?/)?[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+)):(?<currentValue>v?\\d[0-9A-Za-z_.-]*)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
       ],
       "autoReplaceStringTemplate": "{{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{else}}{{#if currentDigest}}@{{{currentDigest}}}{{/if}}{{/if}}",
       "datasourceTemplate": "docker",


### PR DESCRIPTION
## Summary

Refine the repository-side Renovate configuration after enabling `RENOVATE_TOKEN`.

## Changes

- require a slash-delimited image path in the GitHub Actions custom manager so non-image values such as `rsa:2048` and `443:127.0.0.1` are not extracted as Docker dependencies
- retain detection for valid image references such as `kindest/node:v1.36.1` and registry-qualified image paths
- reduce the workflow `GITHUB_TOKEN` to `contents: read`; Renovate writes use the separate `RENOVATE_TOKEN`
- disable persisted checkout credentials
- serialize Renovate runs and add a 30-minute timeout
- explicitly scope Renovate to the current repository

## Rationale

The dedicated Renovate token successfully creates branches and pull requests. The workflow-level write permissions were therefore unnecessary and obscured which credential performs repository mutations. The existing custom regex also matched arbitrary colon-delimited values in composite actions, producing failed lookups for `rsa` and `443`.

## Required secret permissions

`RENOVATE_TOKEN` must independently provide repository contents, pull-request, and issue access. Issue write access is required for Renovate to refresh the Dependency Dashboard; workflow `permissions` do not grant permissions to a separately supplied PAT or GitHub App token.

## Validation

- compared the branch against `main`
- confirmed the diff is limited to `.github/workflows/renovate.yml` and `renovate.jsonc`
- confirmed the custom-manager change is a single quantifier adjustment that requires at least one image-path separator
