### PR TITLE
fix(renovate): classify helm chart updates as fixes

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -81,6 +81,18 @@
       "automerge": false
     },
     {
+      "description": "Classifies Helm chart dependency updates as fixes.",
+      "matchDatasources": [
+        "helm"
+      ],
+      "groupName": "helm chart {{updateType}} versions",
+      "groupSlug": "helm-chart-{{updateType}}-versions",
+      "automerge": false,
+      "semanticCommits": "enabled",
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "deps"
+    },
+    {
       "description": "Container image digest bumps across Dockerfiles and Containerfiles.",
       "matchManagers": [
         "dockerfile",


### PR DESCRIPTION
## Summary

- match Helm chart dependencies through the `helm` datasource
- isolate Helm updates from the generic major/minor/patch groups using an update-type-aware group name and branch slug
- emit Conventional Commit-compatible `fix(deps)` commit messages and PR titles for Helm chart updates

## Rationale

PR #68 demonstrates that Helm chart patch updates are currently grouped with unrelated patch dependencies, resulting in a generic `chore(deps): update patch versions` title. Applying only `semanticCommitType` would remain ambiguous for mixed groups.

This rule is ordered after the generic update-type rules, allowing it to override the group metadata for Helm dependencies while retaining separate major, minor, and patch branches. A future patch group is expected to use a title such as:

```text
fix(deps): update helm chart patch versions
```

## Impact

Future Helm chart dependency updates are represented as fixes according to the repository's Conventional Commit convention and no longer share generic update branches with non-Helm dependencies.

## Validation

- parsed `renovate.jsonc` successfully as JSON
- verified the branch is one commit ahead of `main`
- verified the diff is limited to 12 added lines in `renovate.jsonc`

Refs: #68