### PR TITLE
Group dependency updates with separate GitHub Actions PR

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -54,47 +54,7 @@
   ],
   "packageRules": [
     {
-      "description": "Introduces breaking changes or requires code adjustments due to changes in public APIs.",
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "groupName": "major versions",
-      "groupSlug": "major-versions",
-      "automerge": false
-    },
-    {
-      "description": "Introduces backward-compatible functionality improvements and feature additions.",
-      "matchUpdateTypes": [
-        "minor"
-      ],
-      "groupName": "minor versions",
-      "groupSlug": "minor-versions",
-      "automerge": false
-    },
-    {
-      "description": "Introduces backward-compatible bug fixes and small corrections.",
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "groupName": "patch versions",
-      "groupSlug": "patch-versions",
-      "automerge": false
-    },
-    {
-      "description": "Groups all Helm chart dependency updates into a single pull request and classifies them as fixes.",
-      "matchDatasources": [
-        "helm"
-      ],
-      "groupName": "helm chart updates",
-      "groupSlug": "helm-chart-updates",
-      "separateMajorMinor": false,
-      "automerge": false,
-      "semanticCommits": "enabled",
-      "semanticCommitType": "fix",
-      "semanticCommitScope": "deps"
-    },
-    {
-      "description": "Container image digest bumps across Dockerfiles and Containerfiles.",
+      "description": "Pins and updates container image digests across Dockerfiles and Containerfiles.",
       "matchManagers": [
         "dockerfile",
         "containerfile"
@@ -108,37 +68,37 @@
         "patch",
         "digest"
       ],
-      "groupName": "container digests",
-      "groupSlug": "container-digests",
       "pinDigests": true,
       "automerge": false
     },
     {
-      "description": "Container image tag and digest updates in Makefiles and KinD configuration.",
-      "matchManagers": [
-        "custom.regex"
+      "description": "Groups all dependency updates into a single pull request.",
+      "matchPackageNames": [
+        "*"
       ],
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchFileNames": [
-        "**/[Mm]akefile",
-        "**/GNUMakefile",
-        "**/*.mk",
-        "**/kind-cluster.{yml,yaml}"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch",
-        "digest"
-      ],
-      "groupName": "container images",
-      "groupSlug": "container-images",
-      "automerge": false
+      "groupName": "dependency updates",
+      "groupSlug": "dependency-updates",
+      "separateMajorMinor": false,
+      "automerge": false,
+      "semanticCommits": "enabled",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps"
     },
     {
-      "description": "Container image tag and digest updates in GitHub Actions files.",
+      "description": "Groups GitHub Actions dependency updates into a separate pull request.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github actions updates",
+      "groupSlug": "github-actions-updates",
+      "separateMajorMinor": false,
+      "automerge": false,
+      "semanticCommits": "enabled",
+      "semanticCommitType": "ci",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "description": "Groups container image updates in GitHub Actions metadata into the GitHub Actions pull request.",
       "matchManagers": [
         "custom.regex"
       ],
@@ -154,8 +114,9 @@
         "patch",
         "digest"
       ],
-      "groupName": "github actions container images",
-      "groupSlug": "github-actions-container-images",
+      "groupName": "github actions updates",
+      "groupSlug": "github-actions-updates",
+      "separateMajorMinor": false,
       "automerge": false,
       "semanticCommits": "enabled",
       "semanticCommitType": "ci",

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -81,12 +81,13 @@
       "automerge": false
     },
     {
-      "description": "Classifies Helm chart dependency updates as fixes.",
+      "description": "Groups all Helm chart dependency updates into a single pull request and classifies them as fixes.",
       "matchDatasources": [
         "helm"
       ],
-      "groupName": "helm chart {{updateType}} versions",
-      "groupSlug": "helm-chart-{{updateType}}-versions",
+      "groupName": "helm chart updates",
+      "groupSlug": "helm-chart-updates",
+      "separateMajorMinor": false,
       "automerge": false,
       "semanticCommits": "enabled",
       "semanticCommitType": "fix",


### PR DESCRIPTION
## What changed

- Replaced update-type and ecosystem-specific grouping with one catch-all `dependency updates` group.
- Set `separateMajorMinor: false` so major, minor, patch, digest, and pin updates can share the same dependency PR.
- Added a later `github-actions` manager rule that overrides the catch-all group and creates a separate GitHub Actions PR.
- Assigned custom-regex Docker image updates from `action.yml` and `action.yaml` to the same GitHub Actions group.
- Standardized semantic commits as `chore(deps)` for the general dependency group and `ci(deps)` for GitHub Actions.
- Preserved Dockerfile and Containerfile digest pinning, disabled automerge, vulnerability alerts, release-age controls, and the dependency dashboard.

## Result

Renovate will maintain two primary grouped update branches:

1. `dependency-updates` — all groupable non-GitHub-Actions dependency updates.
2. `github-actions-updates` — native GitHub Actions dependencies plus container images declared in Actions metadata.

Later package rules intentionally override the catch-all group because Renovate merges all matching rules in order.

## Renovate limitations

Replacement updates are never grouped, and lock-file maintenance cannot be grouped with other dependency updates. Those Renovate-defined update classes may still produce separate PRs.

## Validation

- Parsed the complete configuration successfully as JSON.
- Verified the catch-all rule precedes both GitHub Actions override rules.
- Verified both GitHub Actions rules use the same stable group name and slug with `separateMajorMinor: false`.
- Checked the structure against current Renovate documentation for `group:all`, package-rule precedence, and the `github-actions` manager.
- Full `renovate-config-validator` execution was unavailable because the execution environment's npm registry does not expose the `renovate` package.