### PR TITLE
Fix Renovate package rule validation

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -108,12 +108,6 @@
       "matchFileNames": [
         "**/action.{yml,yaml}"
       ],
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch",
-        "digest"
-      ],
       "groupName": "github actions updates",
       "groupSlug": "github-actions-updates",
       "separateMajorMinor": false,


### PR DESCRIPTION
## What changed

- Removed `matchUpdateTypes` from the custom-regex GitHub Actions container-image rule.
- Retained `separateMajorMinor: false` so all matching container-image upgrades remain grouped in the `github-actions-updates` pull request.
- Preserved the existing manager, datasource, file-pattern, automerge, and semantic-commit settings.

## Why

Renovate rejects package rules that combine `matchUpdateTypes` with `separateMajorMinor`. The update-type selector was redundant because this rule is intended to cover every update type.

## Validation

- Parsed the complete `renovate.jsonc` file successfully as JSON.
- Verified the affected rule no longer contains `matchUpdateTypes`.
- Verified the rule still uses the stable `github-actions-updates` group and `separateMajorMinor: false`.

Fixes #77