### PR TITLE
chore: add Kubernetes service operations and diagnostics

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -49,16 +49,29 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Validate Make Kubernetes Rendering
+      - name: Validate Dev Make Rendering
         shell: bash
         run: |
           set -euo pipefail
+          make -s k8s-backup \
+            K8S_ENV=dev \
+            K8S_BACKUP_DIR="${RUNNER_TEMP}/kubernetes-backups/dev"
 
-          for environment in dev stage prod; do
-            make -s k8s-backup \
-              K8S_ENV="${environment}" \
-              K8S_BACKUP_DIR="${RUNNER_TEMP}/kubernetes-backups/${environment}"
-          done
+      - name: Validate Stage Make Rendering
+        shell: bash
+        run: |
+          set -euo pipefail
+          make -s k8s-backup \
+            K8S_ENV=stage \
+            K8S_BACKUP_DIR="${RUNNER_TEMP}/kubernetes-backups/stage"
+
+      - name: Validate Prod Make Rendering
+        shell: bash
+        run: |
+          set -euo pipefail
+          make -s k8s-backup \
+            K8S_ENV=prod \
+            K8S_BACKUP_DIR="${RUNNER_TEMP}/kubernetes-backups/prod"
 
       - name: Test Kind Deployment
         uses: ./.github/actions/kind

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -55,7 +55,9 @@ jobs:
           set -euo pipefail
 
           for environment in dev stage prod; do
-            make -s k8s-render K8S_ENV="${environment}"
+            make -s k8s-backup \
+              K8S_ENV="${environment}" \
+              K8S_BACKUP_DIR="${RUNNER_TEMP}/kubernetes-backups/${environment}"
           done
 
       - name: Test Kind Deployment

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -12,7 +12,9 @@ on:
       - "charts/**"
       - "config/**"
       - "manifests/**"
+      - "GNUmakefile"
       - "Makefile"
+      - "make/**"
       - "scripts/bootstrap.sh"
   pull_request:
     branches:
@@ -23,7 +25,9 @@ on:
       - "charts/**"
       - "config/**"
       - "manifests/**"
+      - "GNUmakefile"
       - "Makefile"
+      - "make/**"
       - "scripts/bootstrap.sh"
   workflow_dispatch:
 
@@ -44,6 +48,18 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Validate Make Kubernetes Rendering
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          make -pn | grep -q '^k8s-backup:'
+          make -pn | grep -q '^k8s-image-hotfix:'
+
+          for environment in dev stage prod; do
+            make -s k8s-render K8S_ENV="${environment}"
+          done
 
       - name: Test Kind Deployment
         uses: ./.github/actions/kind

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -54,9 +54,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          make -pn | grep -q '^k8s-backup:'
-          make -pn | grep -q '^k8s-image-hotfix:'
-
           for environment in dev stage prod; do
             make -s k8s-render K8S_ENV="${environment}"
           done

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -49,19 +49,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Validate Dev Make Rendering
-        shell: bash
-        run: |
-          set -euo pipefail
-          if ! output="$(make -s k8s-backup K8S_ENV=dev K8S_BACKUP_DIR="${RUNNER_TEMP}/kubernetes-backups/dev" 2>&1)"; then
-            printf '%s\n' "${output}" >&2
-            message="${output//'%'/'%25'}"
-            message="${message//$'\r'/'%0D'}"
-            message="${message//$'\n'/'%0A'}"
-            echo "::error title=Dev Make rendering failed::${message}"
-            exit 1
-          fi
-
       - name: Validate Stage Make Rendering
         shell: bash
         run: |

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -53,9 +53,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          make -s k8s-backup \
-            K8S_ENV=dev \
-            K8S_BACKUP_DIR="${RUNNER_TEMP}/kubernetes-backups/dev"
+          if ! output="$(make -s k8s-backup K8S_ENV=dev K8S_BACKUP_DIR="${RUNNER_TEMP}/kubernetes-backups/dev" 2>&1)"; then
+            printf '%s\n' "${output}" >&2
+            message="${output//'%'/'%25'}"
+            message="${message//$'\r'/'%0D'}"
+            message="${message//$'\n'/'%0A'}"
+            echo "::error title=Dev Make rendering failed::${message}"
+            exit 1
+          fi
 
       - name: Validate Stage Make Rendering
         shell: bash

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,4 +3,5 @@
 # Keep the project Makefile as the canonical base and load operational extensions separately.
 include Makefile
 include make/k8s-operations.mk
+include make/k8s-tooling.mk
 include make/k8s-diagnostics.mk

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,3 +3,4 @@
 # Keep the project Makefile as the canonical base and load operational extensions separately.
 include Makefile
 include make/k8s-operations.mk
+include make/k8s-diagnostics.mk

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Keep the project Makefile as the canonical base and load operational extensions separately.
+include Makefile
+include make/k8s-operations.mk

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ githooks-lefthook-initialize:
 	lefthook install --force
 .PHONY: githooks-lefthook-initialize
 
-## Deinitialize Lefthook Git hooks in the local repository
+## Deinitialize Lefthook Git hooks from the local repository
 githooks-lefthook-deinitialize:
 	lefthook uninstall
 .PHONY: githooks-lefthook-deinitialize
@@ -181,7 +181,7 @@ K8S_HELM_ALIAS := docker run --rm -v "$(CURDIR):/workspace" -w /workspace "$(K8S
 # 	helm pull traefik/traefik --version 37.0.0 --untar --untardir charts/
 # .PHONY: helm-vendor-traefik
 
-# # Vendor all Helm charts
+# ## Vendor all Helm charts
 # helm-vendor-charts:
 # 	@$(MAKE) helm-vendor-dependency-track
 # 	@$(MAKE) helm-vendor-postgresql

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ githooks-lefthook-initialize:
 	lefthook install --force
 .PHONY: githooks-lefthook-initialize
 
-## Deinitialize Lefthook Git hooks from the local repository
+## Deinitialize Lefthook Git hooks in the local repository
 githooks-lefthook-deinitialize:
 	lefthook uninstall
 .PHONY: githooks-lefthook-deinitialize
@@ -102,6 +102,9 @@ k8s-teardown:
 
 K8S_TOOLS_IMAGE ?= alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
 K8S_TOOLS_ALIAS := docker run --rm --network host --volume "$(CURDIR):/workspace" --workdir /workspace "$(K8S_TOOLS_IMAGE)"
+K8S_TOOLS_STDIN_ALIAS := docker run --rm --interactive --network host --volume "$(CURDIR):/workspace" --workdir /workspace "$(K8S_TOOLS_IMAGE)"
+K8S_OVERLAY_DIR = manifests/overlays/$(1)/$(2)
+K8S_KUSTOMIZE_BUILD = $(K8S_TOOLS_ALIAS) kustomize build "$(call K8S_OVERLAY_DIR,$(1),$(2))" --enable-helm --load-restrictor=LoadRestrictionsNone
 
 # Interactive user confirmation before proceeding with Kubernetes Deploy & Destroy
 k8s-confirm:
@@ -119,8 +122,8 @@ k8s-confirm:
 template-k8s-deploy-%:
 	@$(MAKE) -s k8s-confirm
 
-	@$(K8S_TOOLS_ALIAS) kustomize build manifests/overlays/$*/$(K8S_STACK_DIR) --enable-helm --load-restrictor=LoadRestrictionsNone \
-		| kubectl apply --kubeconfig $(K8S_KUBECONFIG) -f -
+	@$(call K8S_KUSTOMIZE_BUILD,$*,$(K8S_STACK_DIR)) \
+		| $(K8S_TOOLS_STDIN_ALIAS) kubectl apply --kubeconfig "$(K8S_KUBECONFIG)" -f -
 .PHONY: template-k8s-deploy-%
 
 ## Deploy Kubernetes manifests
@@ -134,8 +137,8 @@ k8s-deploy:
 template-k8s-destroy-%:
 	@$(MAKE) -s k8s-confirm
 
-	@$(K8S_TOOLS_ALIAS) kustomize build manifests/overlays/$*/$(K8S_STACK_DIR) --enable-helm --load-restrictor=LoadRestrictionsNone \
-		| kubectl delete --kubeconfig $(K8S_KUBECONFIG) -f -
+	@$(call K8S_KUSTOMIZE_BUILD,$*,$(K8S_STACK_DIR)) \
+		| $(K8S_TOOLS_STDIN_ALIAS) kubectl delete --kubeconfig "$(K8S_KUBECONFIG)" -f -
 .PHONY: template-k8s-destroy-%
 
 ## Destroy Kubernetes manifests
@@ -147,45 +150,13 @@ k8s-destroy:
 template-k8s-render-%:
 	@mkdir -p render/kustomize/$*/$(K8S_STACK_DIR)
 
-	@$(K8S_TOOLS_ALIAS) kustomize build manifests/overlays/$*/$(K8S_STACK_DIR) --enable-helm --load-restrictor=LoadRestrictionsNone --output=./render/kustomize/$*/$(K8S_STACK_DIR)
+	@$(call K8S_KUSTOMIZE_BUILD,$*,$(K8S_STACK_DIR)) --output=./render/kustomize/$*/$(K8S_STACK_DIR)
 .PHONY: template-k8s-render-%
 
 ## Render Kubernetes manifests
 k8s-render:
 	$(MAKE) template-k8s-render-$(K8S_ENV) K8S_STACK_DIR=dependency-track
 .PHONY: k8s-render
-
-# Observe all services across all namespaces
-k8s-observability-service:
-	$(K8S_TOOLS_ALIAS) kubectl get services --kubeconfig $(K8S_KUBECONFIG)
-.PHONY: k8s-observability-service
-
-# Observe all namespaces
-k8s-observability-namespace:
-	$(K8S_TOOLS_ALIAS) kubectl get namespaces --kubeconfig $(K8S_KUBECONFIG)
-.PHONY: k8s-observability-namespace
-
-# Observe all pods across all namespaces
-k8s-observability-pod:
-	$(K8S_TOOLS_ALIAS) kubectl get pods -A --kubeconfig $(K8S_KUBECONFIG)
-.PHONY: k8s-observability-pod
-
-# Observe all ingress controllers across all namespaces
-k8s-observability-controller:
-	$(K8S_TOOLS_ALIAS) kubectl get ingressclass --kubeconfig $(K8S_KUBECONFIG)
-.PHONY: k8s-observability-controller
-
-## Aggregate Kubernetes observability for services, namespaces, ingress controllers, and pods
-k8s-observability:
-	@echo "──── K8s Services ────────────────────────────────────────────────────────────────────────"
-	@$(MAKE) -s k8s-observability-service
-	@echo "──── K8s Namespaces ──────────────────────────────────────────────────────────────────────"
-	@$(MAKE) -s k8s-observability-namespace
-	@echo "──── K8s Ingress Controllers ─────────────────────────────────────────────────────────────"
-	@$(MAKE) -s k8s-observability-controller
-	@echo "──── K8s Pods ────────────────────────────────────────────────────────────────────────────"
-	@$(MAKE) -s k8s-observability-pod
-.PHONY: k8s-observability
 
 # ── Helm Charts ──────────────────────────────────────────────────────────────────────────────────
 
@@ -210,7 +181,7 @@ K8S_HELM_ALIAS := docker run --rm -v "$(CURDIR):/workspace" -w /workspace "$(K8S
 # 	helm pull traefik/traefik --version 37.0.0 --untar --untardir charts/
 # .PHONY: helm-vendor-traefik
 
-# ## Vendor all Helm charts
+# # Vendor all Helm charts
 # helm-vendor-charts:
 # 	@$(MAKE) helm-vendor-dependency-track
 # 	@$(MAKE) helm-vendor-postgresql

--- a/README.md
+++ b/README.md
@@ -189,7 +189,59 @@ Orchestration platform for automating deployment, scaling, and management of con
       make k8s-debug K8S_POD=<pod> K8S_DEBUG_TARGET=<container>
       ```
 
-4. Integration Diagnostics
+4. Rollout and Rollback Workflows
+
+    - Declarative Rollout
+      > Deploy the environment overlay, then inspect the selected workload state and rollout history. Normal deployments remain declarative and should be reconciled through the Kustomize and Helm configuration in the repository.
+
+      ```bash
+      make k8s-deploy K8S_ENV=<dev|stage|prod>
+      make k8s-describe K8S_RESOURCE_NAME=<deployment>
+      make k8s-monitor K8S_RESOURCE_NAME=<deployment>
+      ```
+
+    - Temporary Image Hotfix
+      > Apply an explicitly temporary live image override. The workflow creates a pre-change desired-state snapshot, shows rollout history, requires environment confirmation, waits for rollout completion, and automatically rolls back on failure by default.
+
+      ```bash
+      make k8s-image-hotfix \
+        K8S_ENV=<dev|stage|prod> \
+        K8S_RESOURCE_NAME=<deployment> \
+        K8S_CONTAINER=<container> \
+        K8S_IMAGE=<image>
+      ```
+
+      > [!IMPORTANT]
+      > A live image hotfix does not update the declarative overlay. Reconcile the Kustomize or Helm image configuration before the next `k8s-deploy`, otherwise the deployment may revert the hotfix. Set `K8S_AUTO_ROLLBACK=false` only when automatic rollback on rollout failure is intentionally disabled.
+
+    - Manual Rollback
+      > Review rollout history, confirm the environment, roll the workload back to the previous revision, and wait for the rollback rollout to complete.
+
+      ```bash
+      make k8s-rollback \
+        K8S_ENV=<dev|stage|prod> \
+        K8S_RESOURCE_NAME=<deployment>
+      ```
+
+      > Roll back to an explicit Kubernetes revision when required.
+
+      ```bash
+      make k8s-rollback \
+        K8S_ENV=<dev|stage|prod> \
+        K8S_RESOURCE_NAME=<deployment> \
+        K8S_ROLLBACK_REVISION=<revision>
+      ```
+
+    - Post-Rollout Verification
+      > Validate workload health and application reachability after a rollout or rollback, then compare live resources against the rendered desired state to detect remaining drift.
+
+      ```bash
+      make k8s-monitor K8S_RESOURCE_NAME=<deployment>
+      make k8s-smoke-test K8S_SMOKE_TEST_URL=<url>
+      make k8s-diff K8S_ENV=<dev|stage|prod>
+      ```
+
+5. Integration Diagnostics
 
     - [Dependency Track](manifests/base/dependency-track/README.md#12-troubleshoot)
       > Integration-specific troubleshooting for ingress routing, TLS, external host reachability, and local Kind host-network or DNS behavior.
@@ -198,5 +250,5 @@ Orchestration platform for automating deployment, scaling, and management of con
 
 - Sentenz [Kubernetes](TODO) article.
 - Sentenz [Template DX](https://github.com/sentenz/template-dx) repository.
-- Sentenz [Actions](https://github.com/sentenz/actions) repository.
+- Sentenz [Actions](https://github.com/sentenz/template-k8s) repository.
 - Sentenz [Manager Tools](https://sentenz.github.io/convention/articles/manager-tools/) article.

--- a/README.md
+++ b/README.md
@@ -250,5 +250,5 @@ Orchestration platform for automating deployment, scaling, and management of con
 
 - Sentenz [Kubernetes](TODO) article.
 - Sentenz [Template DX](https://github.com/sentenz/template-dx) repository.
-- Sentenz [Actions](https://github.com/sentenz/template-k8s) repository.
+- Sentenz [Actions](https://github.com/sentenz/actions) repository.
 - Sentenz [Manager Tools](https://sentenz.github.io/convention/articles/manager-tools/) article.

--- a/README.md
+++ b/README.md
@@ -108,70 +108,91 @@ Orchestration platform for automating deployment, scaling, and management of con
 
 ## 3. Troubleshoot
 
-- Service Diagnostics
-  > Run the default read-only troubleshooting workflow for a Kubernetes workload, including cluster preflight, workload health, Popeye scanning, rollout information, logs, networking, and RBAC checks.
+1. General Diagnostics
 
-  ```bash
-  make k8s-troubleshoot K8S_RESOURCE_NAME=dependency-track
-  ```
+    - Service Diagnostics
+      > Run the default read-only troubleshooting workflow for cluster connectivity, workload health, namespace scanning, rollout information, logs, networking, and RBAC checks.
 
-- Workload Diagnostics
-  > Inspect workload health and capture current, previous, or live multi-Pod container logs.
+      ```bash
+      make k8s-troubleshoot K8S_RESOURCE_NAME=dependency-track
+      ```
 
-  ```bash
-  make k8s-monitor K8S_RESOURCE_NAME=dependency-track
-  make k8s-describe K8S_RESOURCE_NAME=dependency-track
-  make k8s-logs K8S_RESOURCE_NAME=dependency-track
-  make k8s-logs-previous K8S_RESOURCE_NAME=dependency-track
-  make k8s-logs-follow K8S_RESOURCE_NAME=dependency-track
-  ```
+    - Cluster and Namespace Health
+      > Validate Kubernetes API and control-plane connectivity, or scan namespace resources for operational issues using containerized Popeye.
 
-- Kubernetes Health
-  > Scan namespace resources with containerized Popeye or explore Kubernetes resources interactively with containerized K9s in read-only mode by default.
+      ```bash
+      make k8s-preflight
+      make k8s-health-scan
+      ```
 
-  ```bash
-  make k8s-health-scan
-  make k8s-console
-  ```
+2. Workload Diagnostics
 
-- Pod and Node Diagnostics
-  > Drill down into a selected Pod or Node after the general health checks identify a specific failing resource.
+    - Workload State and Logs
+      > Inspect workload state, rollout information, current and previous container logs, or follow live multi-Pod logs using containerized Stern.
 
-  ```bash
-  make k8s-pod-diagnose K8S_POD=<pod>
-  make k8s-node-diagnose K8S_NODE=<node>
-  ```
+      ```bash
+      make k8s-monitor K8S_RESOURCE_NAME=dependency-track
+      make k8s-describe K8S_RESOURCE_NAME=dependency-track
+      make k8s-logs K8S_RESOURCE_NAME=dependency-track
+      make k8s-logs-previous K8S_RESOURCE_NAME=dependency-track
+      make k8s-logs-follow K8S_RESOURCE_NAME=dependency-track
+      ```
 
-- Network and Authorization Diagnostics
-  > Inspect Services, EndpointSlices, Ingresses, NetworkPolicies, and effective Kubernetes RBAC permissions.
+    - Pod and Node Diagnostics
+      > Drill down into a selected Pod or Node after general diagnostics identify a specific failing resource.
 
-  ```bash
-  make k8s-network-diagnose K8S_SERVICE_NAME=<service>
-  make k8s-auth-diagnose
-  make k8s-auth-diagnose K8S_SERVICE_ACCOUNT=<service-account>
-  ```
+      ```bash
+      make k8s-pod-diagnose K8S_POD=<pod>
+      make k8s-node-diagnose K8S_NODE=<node>
+      ```
 
-- Database and Storage Diagnostics
-  > Validate application-to-database DNS and TCP connectivity. Development uses the Kubernetes PostgreSQL service, while stage and production require the AWS RDS endpoint. Kubernetes-managed PostgreSQL storage diagnostics apply to development only.
+    - Interactive Console
+      > Explore Kubernetes resources using containerized K9s in read-only mode by default.
 
-  ```bash
-  make k8s-database-diagnose K8S_ENV=dev
-  make k8s-database-diagnose K8S_ENV=stage K8S_DATABASE_HOST=<rds-endpoint>
-  make k8s-database-diagnose K8S_ENV=prod K8S_DATABASE_HOST=<rds-endpoint>
-  make k8s-storage-diagnose K8S_ENV=dev
-  ```
+      ```bash
+      make k8s-console
+      ```
 
-- Runtime and Desired State Diagnostics
-  > Verify application reachability from inside the namespace, compare rendered Kustomize and Helm desired state against live resources, or attach a containerized Netshoot ephemeral debug container to a selected Pod.
+3. Connectivity and Runtime Diagnostics
 
-  ```bash
-  make k8s-smoke-test K8S_SMOKE_TEST_URL=<url>
-  make k8s-diff K8S_ENV=<dev|stage|prod>
-  make k8s-debug K8S_POD=<pod> [K8S_DEBUG_TARGET=<container>]
-  ```
+    - Network and Authorization Diagnostics
+      > Inspect Services, EndpointSlices, Ingresses, NetworkPolicies, and effective Kubernetes RBAC permissions.
 
-- [Dependency Track](manifests/base/dependency-track/README.md#12-troubleshoot)
-  > Troubleshooting for Dependency Track integration.
+      ```bash
+      make k8s-network-diagnose K8S_SERVICE_NAME=<service>
+      make k8s-auth-diagnose
+      make k8s-auth-diagnose K8S_SERVICE_ACCOUNT=<service-account>
+      ```
+
+    - Database and Storage Diagnostics
+      > Validate application-to-database DNS and TCP connectivity. Development uses Kubernetes PostgreSQL, while stage and production require an AWS RDS endpoint. Kubernetes-managed PostgreSQL storage diagnostics apply to development only.
+
+      ```bash
+      make k8s-database-diagnose K8S_ENV=dev
+      make k8s-database-diagnose K8S_ENV=stage K8S_DATABASE_HOST=<rds-endpoint>
+      make k8s-storage-diagnose K8S_ENV=dev
+      ```
+
+    - Application and Desired State Diagnostics
+      > Verify application reachability from inside the namespace or compare rendered Kustomize and Helm desired state against live Kubernetes resources.
+
+      ```bash
+      make k8s-smoke-test K8S_SMOKE_TEST_URL=<url>
+      make k8s-diff K8S_ENV=stage
+      ```
+
+    - Ephemeral Debug
+      > Attach a containerized Netshoot ephemeral debug container to a selected Pod for deeper network and runtime diagnostics.
+
+      ```bash
+      make k8s-debug K8S_POD=<pod>
+      make k8s-debug K8S_POD=<pod> K8S_DEBUG_TARGET=<container>
+      ```
+
+4. Integration Diagnostics
+
+    - [Dependency Track](manifests/base/dependency-track/README.md#12-troubleshoot)
+      > Troubleshooting for Dependency Track integration.
 
 ## 4. References
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Orchestration platform for automating deployment, scaling, and management of con
       > Run the default read-only troubleshooting workflow for cluster connectivity, workload health, namespace scanning, rollout information, logs, networking, and RBAC checks.
 
       ```bash
-      make k8s-troubleshoot K8S_RESOURCE_NAME=dependency-track
+      make k8s-troubleshoot K8S_RESOURCE_NAME=<deployment>
       ```
 
     - Cluster and Namespace Health
@@ -131,11 +131,11 @@ Orchestration platform for automating deployment, scaling, and management of con
       > Inspect workload state, rollout information, current and previous container logs, or follow live multi-Pod logs using containerized Stern.
 
       ```bash
-      make k8s-monitor K8S_RESOURCE_NAME=dependency-track
-      make k8s-describe K8S_RESOURCE_NAME=dependency-track
-      make k8s-logs K8S_RESOURCE_NAME=dependency-track
-      make k8s-logs-previous K8S_RESOURCE_NAME=dependency-track
-      make k8s-logs-follow K8S_RESOURCE_NAME=dependency-track
+      make k8s-monitor K8S_RESOURCE_NAME=<deployment>
+      make k8s-describe K8S_RESOURCE_NAME=<deployment>
+      make k8s-logs K8S_RESOURCE_NAME=<deployment>
+      make k8s-logs-previous K8S_RESOURCE_NAME=<deployment>
+      make k8s-logs-follow K8S_RESOURCE_NAME=<deployment>
       ```
 
     - Pod and Node Diagnostics
@@ -178,7 +178,7 @@ Orchestration platform for automating deployment, scaling, and management of con
 
       ```bash
       make k8s-smoke-test K8S_SMOKE_TEST_URL=<url>
-      make k8s-diff K8S_ENV=stage
+      make k8s-diff K8S_ENV=<dev|stage|prod>
       ```
 
     - Ephemeral Debug

--- a/README.md
+++ b/README.md
@@ -108,6 +108,68 @@ Orchestration platform for automating deployment, scaling, and management of con
 
 ## 3. Troubleshoot
 
+- Service Diagnostics
+  > Run the default read-only troubleshooting workflow for a Kubernetes workload, including cluster preflight, workload health, Popeye scanning, rollout information, logs, networking, and RBAC checks.
+
+  ```bash
+  make k8s-troubleshoot K8S_RESOURCE_NAME=dependency-track
+  ```
+
+- Workload Diagnostics
+  > Inspect workload health and capture current, previous, or live multi-Pod container logs.
+
+  ```bash
+  make k8s-monitor K8S_RESOURCE_NAME=dependency-track
+  make k8s-describe K8S_RESOURCE_NAME=dependency-track
+  make k8s-logs K8S_RESOURCE_NAME=dependency-track
+  make k8s-logs-previous K8S_RESOURCE_NAME=dependency-track
+  make k8s-logs-follow K8S_RESOURCE_NAME=dependency-track
+  ```
+
+- Kubernetes Health
+  > Scan namespace resources with containerized Popeye or explore Kubernetes resources interactively with containerized K9s in read-only mode by default.
+
+  ```bash
+  make k8s-health-scan
+  make k8s-console
+  ```
+
+- Pod and Node Diagnostics
+  > Drill down into a selected Pod or Node after the general health checks identify a specific failing resource.
+
+  ```bash
+  make k8s-pod-diagnose K8S_POD=<pod>
+  make k8s-node-diagnose K8S_NODE=<node>
+  ```
+
+- Network and Authorization Diagnostics
+  > Inspect Services, EndpointSlices, Ingresses, NetworkPolicies, and effective Kubernetes RBAC permissions.
+
+  ```bash
+  make k8s-network-diagnose K8S_SERVICE_NAME=<service>
+  make k8s-auth-diagnose
+  make k8s-auth-diagnose K8S_SERVICE_ACCOUNT=<service-account>
+  ```
+
+- Database and Storage Diagnostics
+  > Validate application-to-database DNS and TCP connectivity. Development uses the Kubernetes PostgreSQL service, while stage and production require the AWS RDS endpoint. Kubernetes-managed PostgreSQL storage diagnostics apply to development only.
+
+  ```bash
+  make k8s-database-diagnose K8S_ENV=dev
+  make k8s-database-diagnose K8S_ENV=stage K8S_DATABASE_HOST=<rds-endpoint>
+  make k8s-database-diagnose K8S_ENV=prod K8S_DATABASE_HOST=<rds-endpoint>
+  make k8s-storage-diagnose K8S_ENV=dev
+  ```
+
+- Runtime and Desired State Diagnostics
+  > Verify application reachability from inside the namespace, compare rendered Kustomize and Helm desired state against live resources, or attach a containerized Netshoot ephemeral debug container to a selected Pod.
+
+  ```bash
+  make k8s-smoke-test K8S_SMOKE_TEST_URL=<url>
+  make k8s-diff K8S_ENV=<dev|stage|prod>
+  make k8s-debug K8S_POD=<pod> [K8S_DEBUG_TARGET=<container>]
+  ```
+
 - [Dependency Track](manifests/base/dependency-track/README.md#12-troubleshoot)
   > Troubleshooting for Dependency Track integration.
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Orchestration platform for automating deployment, scaling, and management of con
 4. Integration Diagnostics
 
     - [Dependency Track](manifests/base/dependency-track/README.md#12-troubleshoot)
-      > Troubleshooting for Dependency Track integration.
+      > Integration-specific troubleshooting for ingress routing, TLS, external host reachability, and local Kind host-network or DNS behavior.
 
 ## 4. References
 

--- a/make/k8s-diagnostics.mk
+++ b/make/k8s-diagnostics.mk
@@ -6,9 +6,8 @@ K8S_POD ?=
 K8S_NODE ?=
 K8S_SERVICE_NAME ?=
 K8S_SERVICE_ACCOUNT ?=
-K8S_DEBUG_IMAGE ?=
+K8S_DEBUG_IMAGE ?= $(K8S_NETSHOOT_IMAGE)
 K8S_DEBUG_TARGET ?=
-K8S_DIAGNOSTIC_IMAGE ?= busybox:1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028
 K8S_SMOKE_TEST_URL ?=
 K8S_SMOKE_TEST_TIMEOUT ?= 10
 K8S_DATABASE_HOST ?=
@@ -23,12 +22,7 @@ K8S_DIAGNOSTIC_RUN_FLAGS = --namespace "$(K8S_OPERATIONS_NAMESPACE)" --kubeconfi
 k8s-require-debug:
 	@if [[ -z "$(strip $(K8S_POD))" ]]; then \
 		echo "error: K8S_POD is required" >&2; \
-		echo "usage: make k8s-debug K8S_POD=<pod> K8S_DEBUG_IMAGE=<image> [K8S_DEBUG_TARGET=<container>]" >&2; \
-		exit 2; \
-	fi
-
-	@if [[ -z "$(strip $(K8S_DEBUG_IMAGE))" ]]; then \
-		echo "error: K8S_DEBUG_IMAGE is required" >&2; \
+		echo "usage: make k8s-debug K8S_POD=<pod> [K8S_DEBUG_IMAGE=<image>] [K8S_DEBUG_TARGET=<container>]" >&2; \
 		exit 2; \
 	fi
 .PHONY: k8s-require-debug
@@ -195,10 +189,10 @@ k8s-smoke-test: k8s-require-smoke-test
 	@set -euo pipefail; \
 	pod_name="k8s-smoke-$$(date +%s)-$${RANDOM}"; \
 	$(K8S_DIAGNOSTIC_RUN) "$$pod_name" $(K8S_DIAGNOSTIC_RUN_FLAGS) \
-		wget -S -T "$(K8S_SMOKE_TEST_TIMEOUT)" -O /dev/null "$(K8S_SMOKE_TEST_URL)"
+		curl --fail --show-error --silent --max-time "$(K8S_SMOKE_TEST_TIMEOUT)" --output /dev/null "$(K8S_SMOKE_TEST_URL)"
 .PHONY: k8s-smoke-test
 
-## Launch an interactive ephemeral debug container in a Kubernetes Pod
+## Launch an interactive Netshoot ephemeral debug container in a Kubernetes Pod
 k8s-debug: k8s-require-debug
 	@$(K8S_TOOLS_INTERACTIVE_ALIAS) kubectl debug \
 		"pod/$(K8S_POD)" \

--- a/make/k8s-diagnostics.mk
+++ b/make/k8s-diagnostics.mk
@@ -18,14 +18,23 @@ K8S_TOOLS_INTERACTIVE_ALIAS := docker run --rm --interactive --tty --network hos
 K8S_DIAGNOSTIC_RUN = $(K8S_TOOLS_ALIAS) kubectl run
 K8S_DIAGNOSTIC_RUN_FLAGS = --namespace "$(K8S_OPERATIONS_NAMESPACE)" --kubeconfig "$(K8S_KUBECONFIG)" --image="$(K8S_DIAGNOSTIC_IMAGE)" --restart=Never --attach=true --rm --command --
 
-# Validate parameters required for ephemeral container debugging
-k8s-require-debug:
+# Validate that a Kubernetes Pod was specified for drill-down diagnostics
+k8s-require-pod:
 	@if [[ -z "$(strip $(K8S_POD))" ]]; then \
 		echo "error: K8S_POD is required" >&2; \
-		echo "usage: make k8s-debug K8S_POD=<pod> [K8S_DEBUG_IMAGE=<image>] [K8S_DEBUG_TARGET=<container>]" >&2; \
+		echo "usage: make <target> K8S_POD=<pod>" >&2; \
 		exit 2; \
 	fi
-.PHONY: k8s-require-debug
+.PHONY: k8s-require-pod
+
+# Validate that a Kubernetes Node was specified for drill-down diagnostics
+k8s-require-node:
+	@if [[ -z "$(strip $(K8S_NODE))" ]]; then \
+		echo "error: K8S_NODE is required" >&2; \
+		echo "usage: make k8s-node-diagnose K8S_NODE=<node>" >&2; \
+		exit 2; \
+	fi
+.PHONY: k8s-require-node
 
 # Validate parameters required for an application smoke test
 k8s-require-smoke-test:
@@ -36,7 +45,7 @@ k8s-require-smoke-test:
 	fi
 .PHONY: k8s-require-smoke-test
 
-## Verify Kubernetes API connectivity, control-plane readiness, versions, and node health
+## Verify Kubernetes API connectivity, control-plane readiness, versions, and node visibility
 k8s-preflight:
 	@echo "──── Kubernetes Version ──────────────────────────────────────────────────────────────────"
 	@$(K8S_TOOLS_ALIAS) kubectl version --kubeconfig "$(K8S_KUBECONFIG)"
@@ -52,41 +61,33 @@ k8s-preflight:
 	@$(K8S_TOOLS_ALIAS) kubectl get nodes --kubeconfig "$(K8S_KUBECONFIG)" -o wide
 .PHONY: k8s-preflight
 
-## Diagnose pod readiness, restart counts, container states, probes, scheduling, and events
-k8s-pod-diagnose:
-	@echo "──── Pod State Summary ───────────────────────────────────────────────────────────────────"
-	@$(K8S_TOOLS_ALIAS) kubectl get pods \
+## Diagnose one Kubernetes Pod's readiness, restart counts, container states, scheduling, probes, and events
+k8s-pod-diagnose: k8s-require-pod
+	@echo "──── Pod State ────────────────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl get "pod/$(K8S_POD)" \
 		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 		--kubeconfig "$(K8S_KUBECONFIG)" \
 		-o custom-columns='NAME:.metadata.name,READY:.status.containerStatuses[*].ready,RESTARTS:.status.containerStatuses[*].restartCount,WAITING:.status.containerStatuses[*].state.waiting.reason,PREVIOUS:.status.containerStatuses[*].lastState.terminated.reason,NODE:.spec.nodeName'
 
 	@echo "──── Pod Description ─────────────────────────────────────────────────────────────────────"
-	@if [[ -n "$(strip $(K8S_POD))" ]]; then \
-		$(K8S_TOOLS_ALIAS) kubectl describe "pod/$(K8S_POD)" \
-			--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
-			--kubeconfig "$(K8S_KUBECONFIG)"; \
-	else \
-		$(K8S_TOOLS_ALIAS) kubectl describe pods \
-			--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
-			--kubeconfig "$(K8S_KUBECONFIG)"; \
-	fi
+	@$(K8S_TOOLS_ALIAS) kubectl describe "pod/$(K8S_POD)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)"
 .PHONY: k8s-pod-diagnose
 
-## Diagnose node readiness, pressure conditions, resource usage, taints, and capacity
-k8s-node-diagnose:
+## Diagnose one Kubernetes Node's readiness, pressure conditions, taints, capacity, and workloads
+k8s-node-diagnose: k8s-require-node
 	@echo "──── Node State ──────────────────────────────────────────────────────────────────────────"
-	@$(K8S_TOOLS_ALIAS) kubectl get nodes \
+	@$(K8S_TOOLS_ALIAS) kubectl get "node/$(K8S_NODE)" \
 		--kubeconfig "$(K8S_KUBECONFIG)" \
 		-o custom-columns='NAME:.metadata.name,READY:.status.conditions[?(@.type=="Ready")].status,MEMORY-PRESSURE:.status.conditions[?(@.type=="MemoryPressure")].status,DISK-PRESSURE:.status.conditions[?(@.type=="DiskPressure")].status,PID-PRESSURE:.status.conditions[?(@.type=="PIDPressure")].status,VERSION:.status.nodeInfo.kubeletVersion'
 
-	@echo "──── Node Resource Usage ─────────────────────────────────────────────────────────────────"
-	@$(K8S_TOOLS_ALIAS) kubectl top nodes --kubeconfig "$(K8S_KUBECONFIG)" \
+	@echo "──── Selected Node Resource Usage ────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl top "node/$(K8S_NODE)" --kubeconfig "$(K8S_KUBECONFIG)" \
 		|| echo "Metrics API unavailable; skipping node resource usage."
 
-	@if [[ -n "$(strip $(K8S_NODE))" ]]; then \
-		echo "──── Selected Node Description ───────────────────────────────────────────────────────────"; \
-		$(K8S_TOOLS_ALIAS) kubectl describe "node/$(K8S_NODE)" --kubeconfig "$(K8S_KUBECONFIG)"; \
-	fi
+	@echo "──── Node Description ────────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl describe "node/$(K8S_NODE)" --kubeconfig "$(K8S_KUBECONFIG)"
 .PHONY: k8s-node-diagnose
 
 ## Diagnose Service selectors, EndpointSlices, ingress routing, and NetworkPolicies
@@ -193,7 +194,7 @@ k8s-smoke-test: k8s-require-smoke-test
 .PHONY: k8s-smoke-test
 
 ## Launch an interactive Netshoot ephemeral debug container in a Kubernetes Pod
-k8s-debug: k8s-require-debug
+k8s-debug: k8s-require-pod
 	@$(K8S_TOOLS_INTERACTIVE_ALIAS) kubectl debug \
 		"pod/$(K8S_POD)" \
 		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
@@ -203,11 +204,11 @@ k8s-debug: k8s-require-debug
 		--tty
 .PHONY: k8s-debug
 
-## Troubleshoot a Kubernetes service using cluster, workload, pod, network, RBAC, event, and log diagnostics
+## Troubleshoot a Kubernetes service using deterministic checks plus a Popeye health scan
 k8s-troubleshoot: k8s-require-resource
 	@$(MAKE) -s k8s-preflight || echo "Preflight diagnostics reported an issue."
 	@$(MAKE) -s k8s-monitor
-	@$(MAKE) -s k8s-pod-diagnose || echo "Pod diagnostics unavailable."
+	@$(MAKE) -s k8s-health-scan || echo "Popeye health scan reported an issue."
 	@$(MAKE) -s k8s-describe
 	@echo "──── Recent Logs ─────────────────────────────────────────────────────────────────────────"
 	@$(MAKE) -s k8s-logs || echo "Logs unavailable for the selected workload."

--- a/make/k8s-diagnostics.mk
+++ b/make/k8s-diagnostics.mk
@@ -14,7 +14,10 @@ K8S_SMOKE_TEST_TIMEOUT ?= 10
 K8S_DATABASE_HOST ?=
 K8S_DATABASE_PORT ?= 5432
 K8S_POSTGRES_NAMESPACE ?= postgresql
+K8S_TOOLS_STDIN_ALIAS := docker run --rm --interactive --network host --volume "$(CURDIR):/workspace" --workdir /workspace "$(K8S_TOOLS_IMAGE)"
 K8S_TOOLS_INTERACTIVE_ALIAS := docker run --rm --interactive --tty --network host --volume "$(CURDIR):/workspace" --workdir /workspace "$(K8S_TOOLS_IMAGE)"
+K8S_DIAGNOSTIC_RUN = $(K8S_TOOLS_ALIAS) kubectl run
+K8S_DIAGNOSTIC_RUN_FLAGS = --namespace "$(K8S_OPERATIONS_NAMESPACE)" --kubeconfig "$(K8S_KUBECONFIG)" --image="$(K8S_DIAGNOSTIC_IMAGE)" --restart=Never --attach=true --rm --command --
 
 # Validate parameters required for ephemeral container debugging
 k8s-require-debug:
@@ -91,19 +94,6 @@ k8s-node-diagnose:
 		$(K8S_TOOLS_ALIAS) kubectl describe "node/$(K8S_NODE)" --kubeconfig "$(K8S_KUBECONFIG)"; \
 	fi
 .PHONY: k8s-node-diagnose
-
-## Retrieve logs from the previous terminated container instances of a Kubernetes workload
-k8s-logs-previous: k8s-require-resource
-	@$(K8S_TOOLS_ALIAS) kubectl logs \
-		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
-		--kubeconfig "$(K8S_KUBECONFIG)" \
-		--all-containers=true \
-		--all-pods=true \
-		--prefix=true \
-		--previous=true \
-		--tail="$(K8S_LOG_TAIL)"
-.PHONY: k8s-logs-previous
 
 ## Diagnose Service selectors, EndpointSlices, ingress routing, and NetworkPolicies
 k8s-network-diagnose:
@@ -188,29 +178,14 @@ k8s-database-diagnose: k8s-require-env
 	fi; \
 	echo "Testing database connectivity from namespace '$(K8S_OPERATIONS_NAMESPACE)' to $$db_host:$(K8S_DATABASE_PORT)"; \
 	pod_name="k8s-db-diagnose-$$(date +%s)-$${RANDOM}"; \
-	$(K8S_TOOLS_ALIAS) kubectl run "$$pod_name" \
-		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
-		--kubeconfig "$(K8S_KUBECONFIG)" \
-		--image="$(K8S_DIAGNOSTIC_IMAGE)" \
-		--restart=Never \
-		--attach=true \
-		--rm \
-		--command -- sh -ec 'nslookup "$$1"; timeout 5 nc "$$1" "$$2" </dev/null >/dev/null' _ "$$db_host" "$(K8S_DATABASE_PORT)"
+	$(K8S_DIAGNOSTIC_RUN) "$$pod_name" $(K8S_DIAGNOSTIC_RUN_FLAGS) \
+		sh -ec 'nslookup "$$1"; timeout 5 nc "$$1" "$$2" </dev/null >/dev/null' _ "$$db_host" "$(K8S_DATABASE_PORT)"
 .PHONY: k8s-database-diagnose
 
 ## Compare rendered Kustomize/Helm desired state with live Kubernetes resources
-k8s-diff: k8s-require-env
-	@set -euo pipefail; \
-	overlay_dir="manifests/overlays/$(K8S_ENV)/$(K8S_SERVICE)"; \
-	if [[ ! -f "$$overlay_dir/kustomization.yaml" ]]; then \
-		echo "error: Kubernetes overlay does not exist: $$overlay_dir" >&2; \
-		exit 2; \
-	fi; \
-	$(K8S_TOOLS_ALIAS) kustomize build \
-		"$$overlay_dir" \
-		--enable-helm \
-		--load-restrictor=LoadRestrictionsNone \
-		| $(K8S_TOOLS_ALIAS) kubectl diff \
+k8s-diff: k8s-require-overlay
+	@$(K8S_KUSTOMIZE_BUILD) \
+		| $(K8S_TOOLS_STDIN_ALIAS) kubectl diff \
 			--kubeconfig "$(K8S_KUBECONFIG)" \
 			-f -
 .PHONY: k8s-diff
@@ -219,14 +194,8 @@ k8s-diff: k8s-require-env
 k8s-smoke-test: k8s-require-smoke-test
 	@set -euo pipefail; \
 	pod_name="k8s-smoke-$$(date +%s)-$${RANDOM}"; \
-	$(K8S_TOOLS_ALIAS) kubectl run "$$pod_name" \
-		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
-		--kubeconfig "$(K8S_KUBECONFIG)" \
-		--image="$(K8S_DIAGNOSTIC_IMAGE)" \
-		--restart=Never \
-		--attach=true \
-		--rm \
-		--command -- wget -S -T "$(K8S_SMOKE_TEST_TIMEOUT)" -O /dev/null "$(K8S_SMOKE_TEST_URL)"
+	$(K8S_DIAGNOSTIC_RUN) "$$pod_name" $(K8S_DIAGNOSTIC_RUN_FLAGS) \
+		wget -S -T "$(K8S_SMOKE_TEST_TIMEOUT)" -O /dev/null "$(K8S_SMOKE_TEST_URL)"
 .PHONY: k8s-smoke-test
 
 ## Launch an interactive ephemeral debug container in a Kubernetes Pod
@@ -240,14 +209,16 @@ k8s-debug: k8s-require-debug
 		--tty
 .PHONY: k8s-debug
 
-# Run supplemental read-only diagnostics before the existing k8s-troubleshoot recipe
-k8s-troubleshoot-diagnostics: k8s-require-resource
+## Troubleshoot a Kubernetes service using cluster, workload, pod, network, RBAC, event, and log diagnostics
+k8s-troubleshoot: k8s-require-resource
 	@$(MAKE) -s k8s-preflight || echo "Preflight diagnostics reported an issue."
+	@$(MAKE) -s k8s-monitor
 	@$(MAKE) -s k8s-pod-diagnose || echo "Pod diagnostics unavailable."
+	@$(MAKE) -s k8s-describe
+	@echo "──── Recent Logs ─────────────────────────────────────────────────────────────────────────"
+	@$(MAKE) -s k8s-logs || echo "Logs unavailable for the selected workload."
 	@echo "──── Previous Container Logs ─────────────────────────────────────────────────────────────"
 	@$(MAKE) -s k8s-logs-previous || echo "No previous container logs are available."
 	@$(MAKE) -s k8s-network-diagnose || echo "Network diagnostics reported an issue."
 	@$(MAKE) -s k8s-auth-diagnose || echo "RBAC diagnostics reported an issue."
-.PHONY: k8s-troubleshoot-diagnostics
-
-k8s-troubleshoot: k8s-troubleshoot-diagnostics
+.PHONY: k8s-troubleshoot

--- a/make/k8s-diagnostics.mk
+++ b/make/k8s-diagnostics.mk
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# ── Kubernetes Service Diagnostics ────────────────────────────────────────────────────────────────
+
+K8S_POD ?=
+K8S_NODE ?=
+K8S_SERVICE_NAME ?=
+K8S_SERVICE_ACCOUNT ?=
+K8S_DEBUG_IMAGE ?=
+K8S_DEBUG_TARGET ?=
+K8S_DIAGNOSTIC_IMAGE ?= busybox:1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028
+K8S_SMOKE_TEST_URL ?=
+K8S_SMOKE_TEST_TIMEOUT ?= 10
+K8S_DATABASE_HOST ?=
+K8S_DATABASE_PORT ?= 5432
+K8S_POSTGRES_NAMESPACE ?= postgresql
+K8S_TOOLS_INTERACTIVE_ALIAS := docker run --rm --interactive --tty --network host --volume "$(CURDIR):/workspace" --workdir /workspace "$(K8S_TOOLS_IMAGE)"
+
+# Validate parameters required for ephemeral container debugging
+k8s-require-debug:
+	@if [[ -z "$(strip $(K8S_POD))" ]]; then \
+		echo "error: K8S_POD is required" >&2; \
+		echo "usage: make k8s-debug K8S_POD=<pod> K8S_DEBUG_IMAGE=<image> [K8S_DEBUG_TARGET=<container>]" >&2; \
+		exit 2; \
+	fi
+
+	@if [[ -z "$(strip $(K8S_DEBUG_IMAGE))" ]]; then \
+		echo "error: K8S_DEBUG_IMAGE is required" >&2; \
+		exit 2; \
+	fi
+.PHONY: k8s-require-debug
+
+# Validate parameters required for an application smoke test
+k8s-require-smoke-test:
+	@if [[ -z "$(strip $(K8S_SMOKE_TEST_URL))" ]]; then \
+		echo "error: K8S_SMOKE_TEST_URL is required" >&2; \
+		echo "usage: make k8s-smoke-test K8S_SMOKE_TEST_URL=<url>" >&2; \
+		exit 2; \
+	fi
+.PHONY: k8s-require-smoke-test
+
+## Verify Kubernetes API connectivity, control-plane readiness, versions, and node health
+k8s-preflight:
+	@echo "──── Kubernetes Version ──────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl version --kubeconfig "$(K8S_KUBECONFIG)"
+
+	@echo "──── Cluster Information ─────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl cluster-info --kubeconfig "$(K8S_KUBECONFIG)"
+
+	@echo "──── API Readiness ────────────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl get --raw='/readyz?verbose' --kubeconfig "$(K8S_KUBECONFIG)" \
+		|| echo "Kubernetes API readiness endpoint unavailable to the current identity."
+
+	@echo "──── Nodes ────────────────────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl get nodes --kubeconfig "$(K8S_KUBECONFIG)" -o wide
+.PHONY: k8s-preflight
+
+## Diagnose pod readiness, restart counts, container states, probes, scheduling, and events
+k8s-pod-diagnose:
+	@echo "──── Pod State Summary ───────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl get pods \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		-o custom-columns='NAME:.metadata.name,READY:.status.containerStatuses[*].ready,RESTARTS:.status.containerStatuses[*].restartCount,WAITING:.status.containerStatuses[*].state.waiting.reason,PREVIOUS:.status.containerStatuses[*].lastState.terminated.reason,NODE:.spec.nodeName'
+
+	@echo "──── Pod Description ─────────────────────────────────────────────────────────────────────"
+	@if [[ -n "$(strip $(K8S_POD))" ]]; then \
+		$(K8S_TOOLS_ALIAS) kubectl describe "pod/$(K8S_POD)" \
+			--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+			--kubeconfig "$(K8S_KUBECONFIG)"; \
+	else \
+		$(K8S_TOOLS_ALIAS) kubectl describe pods \
+			--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+			--kubeconfig "$(K8S_KUBECONFIG)"; \
+	fi
+.PHONY: k8s-pod-diagnose
+
+## Diagnose node readiness, pressure conditions, resource usage, taints, and capacity
+k8s-node-diagnose:
+	@echo "──── Node State ──────────────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl get nodes \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		-o custom-columns='NAME:.metadata.name,READY:.status.conditions[?(@.type=="Ready")].status,MEMORY-PRESSURE:.status.conditions[?(@.type=="MemoryPressure")].status,DISK-PRESSURE:.status.conditions[?(@.type=="DiskPressure")].status,PID-PRESSURE:.status.conditions[?(@.type=="PIDPressure")].status,VERSION:.status.nodeInfo.kubeletVersion'
+
+	@echo "──── Node Resource Usage ─────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl top nodes --kubeconfig "$(K8S_KUBECONFIG)" \
+		|| echo "Metrics API unavailable; skipping node resource usage."
+
+	@if [[ -n "$(strip $(K8S_NODE))" ]]; then \
+		echo "──── Selected Node Description ───────────────────────────────────────────────────────────"; \
+		$(K8S_TOOLS_ALIAS) kubectl describe "node/$(K8S_NODE)" --kubeconfig "$(K8S_KUBECONFIG)"; \
+	fi
+.PHONY: k8s-node-diagnose
+
+## Retrieve logs from the previous terminated container instances of a Kubernetes workload
+k8s-logs-previous: k8s-require-resource
+	@$(K8S_TOOLS_ALIAS) kubectl logs \
+		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		--all-containers=true \
+		--all-pods=true \
+		--prefix=true \
+		--previous=true \
+		--tail="$(K8S_LOG_TAIL)"
+.PHONY: k8s-logs-previous
+
+## Diagnose Service selectors, EndpointSlices, ingress routing, and NetworkPolicies
+k8s-network-diagnose:
+	@echo "──── Network Resources ───────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl get \
+		services,endpointslices,ingresses,networkpolicies \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		-o wide
+
+	@if [[ -n "$(strip $(K8S_SERVICE_NAME))" ]]; then \
+		echo "──── Selected Service ────────────────────────────────────────────────────────────────────"; \
+		$(K8S_TOOLS_ALIAS) kubectl describe "service/$(K8S_SERVICE_NAME)" \
+			--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+			--kubeconfig "$(K8S_KUBECONFIG)"; \
+		echo "──── Selected Service EndpointSlices ─────────────────────────────────────────────────────"; \
+		$(K8S_TOOLS_ALIAS) kubectl get endpointslices \
+			--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+			--kubeconfig "$(K8S_KUBECONFIG)" \
+			--selector "kubernetes.io/service-name=$(K8S_SERVICE_NAME)" \
+			-o wide; \
+	fi
+.PHONY: k8s-network-diagnose
+
+## Diagnose effective Kubernetes RBAC permissions for the current identity or a ServiceAccount
+k8s-auth-diagnose:
+	@set -euo pipefail; \
+	identity_args=(); \
+	if [[ -n "$(strip $(K8S_SERVICE_ACCOUNT))" ]]; then \
+		identity_args+=("--as=system:serviceaccount:$(K8S_OPERATIONS_NAMESPACE):$(K8S_SERVICE_ACCOUNT)"); \
+	fi; \
+	echo "──── Kubernetes Identity ─────────────────────────────────────────────────────────────────"; \
+	$(K8S_TOOLS_ALIAS) kubectl auth whoami \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		"$${identity_args[@]}" || true; \
+	echo "──── Effective Namespace Permissions ────────────────────────────────────────────────────"; \
+	$(K8S_TOOLS_ALIAS) kubectl auth can-i --list \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		"$${identity_args[@]}"
+.PHONY: k8s-auth-diagnose
+
+## Diagnose Kubernetes-managed PostgreSQL storage in dev; stage and prod use AWS RDS
+k8s-storage-diagnose: k8s-require-env
+	@if [[ "$(K8S_ENV)" != "dev" ]]; then \
+		echo "Kubernetes PostgreSQL storage diagnostics skipped: $(K8S_ENV) uses AWS RDS."; \
+		exit 0; \
+	fi
+
+	@echo "──── PostgreSQL Workload & Persistent Storage ────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl get \
+		statefulsets,pods,services,persistentvolumeclaims \
+		--namespace "$(K8S_POSTGRES_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		-o wide
+
+	@echo "──── Storage Classes & Persistent Volumes ────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl get storageclasses,persistentvolumes \
+		--kubeconfig "$(K8S_KUBECONFIG)"
+
+	@echo "──── PostgreSQL Storage Warning Events ───────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl get events \
+		--namespace "$(K8S_POSTGRES_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		--field-selector type=Warning \
+		--sort-by=.lastTimestamp
+.PHONY: k8s-storage-diagnose
+
+## Validate application-to-database DNS and TCP connectivity; dev uses Kubernetes PostgreSQL and stage/prod use AWS RDS
+k8s-database-diagnose: k8s-require-env
+	@set -euo pipefail; \
+	db_host="$(strip $(K8S_DATABASE_HOST))"; \
+	if [[ "$(K8S_ENV)" == "dev" ]]; then \
+		$(MAKE) -s k8s-storage-diagnose; \
+		if [[ -z "$$db_host" ]]; then \
+			db_host="postgresql.$(K8S_POSTGRES_NAMESPACE).svc.cluster.local"; \
+		fi; \
+	elif [[ -z "$$db_host" ]]; then \
+		echo "error: K8S_DATABASE_HOST is required for $(K8S_ENV) because the database is external AWS RDS" >&2; \
+		echo "usage: make k8s-database-diagnose K8S_ENV=$(K8S_ENV) K8S_DATABASE_HOST=<rds-endpoint>" >&2; \
+		exit 2; \
+	fi; \
+	echo "Testing database connectivity from namespace '$(K8S_OPERATIONS_NAMESPACE)' to $$db_host:$(K8S_DATABASE_PORT)"; \
+	pod_name="k8s-db-diagnose-$$(date +%s)-$${RANDOM}"; \
+	$(K8S_TOOLS_ALIAS) kubectl run "$$pod_name" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		--image="$(K8S_DIAGNOSTIC_IMAGE)" \
+		--restart=Never \
+		--attach=true \
+		--rm \
+		--command -- sh -ec 'nslookup "$$1"; timeout 5 nc "$$1" "$$2" </dev/null >/dev/null' _ "$$db_host" "$(K8S_DATABASE_PORT)"
+.PHONY: k8s-database-diagnose
+
+## Compare rendered Kustomize/Helm desired state with live Kubernetes resources
+k8s-diff: k8s-require-env
+	@set -euo pipefail; \
+	overlay_dir="manifests/overlays/$(K8S_ENV)/$(K8S_SERVICE)"; \
+	if [[ ! -f "$$overlay_dir/kustomization.yaml" ]]; then \
+		echo "error: Kubernetes overlay does not exist: $$overlay_dir" >&2; \
+		exit 2; \
+	fi; \
+	$(K8S_TOOLS_ALIAS) kustomize build \
+		"$$overlay_dir" \
+		--enable-helm \
+		--load-restrictor=LoadRestrictionsNone \
+		| $(K8S_TOOLS_ALIAS) kubectl diff \
+			--kubeconfig "$(K8S_KUBECONFIG)" \
+			-f -
+.PHONY: k8s-diff
+
+## Run an application-level HTTP(S) smoke test from inside the Kubernetes service namespace
+k8s-smoke-test: k8s-require-smoke-test
+	@set -euo pipefail; \
+	pod_name="k8s-smoke-$$(date +%s)-$${RANDOM}"; \
+	$(K8S_TOOLS_ALIAS) kubectl run "$$pod_name" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		--image="$(K8S_DIAGNOSTIC_IMAGE)" \
+		--restart=Never \
+		--attach=true \
+		--rm \
+		--command -- wget -S -T "$(K8S_SMOKE_TEST_TIMEOUT)" -O /dev/null "$(K8S_SMOKE_TEST_URL)"
+.PHONY: k8s-smoke-test
+
+## Launch an interactive ephemeral debug container in a Kubernetes Pod
+k8s-debug: k8s-require-debug
+	@$(K8S_TOOLS_INTERACTIVE_ALIAS) kubectl debug \
+		"pod/$(K8S_POD)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		--image="$(K8S_DEBUG_IMAGE)" $(if $(strip $(K8S_DEBUG_TARGET)),--target="$(K8S_DEBUG_TARGET)",) \
+		--interactive \
+		--tty
+.PHONY: k8s-debug
+
+# Run supplemental read-only diagnostics before the existing k8s-troubleshoot recipe
+k8s-troubleshoot-diagnostics: k8s-require-resource
+	@$(MAKE) -s k8s-preflight || echo "Preflight diagnostics reported an issue."
+	@$(MAKE) -s k8s-pod-diagnose || echo "Pod diagnostics unavailable."
+	@echo "──── Previous Container Logs ─────────────────────────────────────────────────────────────"
+	@$(MAKE) -s k8s-logs-previous || echo "No previous container logs are available."
+	@$(MAKE) -s k8s-network-diagnose || echo "Network diagnostics reported an issue."
+	@$(MAKE) -s k8s-auth-diagnose || echo "RBAC diagnostics reported an issue."
+.PHONY: k8s-troubleshoot-diagnostics
+
+k8s-troubleshoot: k8s-troubleshoot-diagnostics

--- a/make/k8s-diagnostics.mk
+++ b/make/k8s-diagnostics.mk
@@ -13,7 +13,6 @@ K8S_SMOKE_TEST_TIMEOUT ?= 10
 K8S_DATABASE_HOST ?=
 K8S_DATABASE_PORT ?= 5432
 K8S_POSTGRES_NAMESPACE ?= postgresql
-K8S_TOOLS_STDIN_ALIAS := docker run --rm --interactive --network host --volume "$(CURDIR):/workspace" --workdir /workspace "$(K8S_TOOLS_IMAGE)"
 K8S_TOOLS_INTERACTIVE_ALIAS := docker run --rm --interactive --tty --network host --volume "$(CURDIR):/workspace" --workdir /workspace "$(K8S_TOOLS_IMAGE)"
 K8S_DIAGNOSTIC_RUN = $(K8S_TOOLS_ALIAS) kubectl run
 K8S_DIAGNOSTIC_RUN_FLAGS = --namespace "$(K8S_OPERATIONS_NAMESPACE)" --kubeconfig "$(K8S_KUBECONFIG)" --image="$(K8S_DIAGNOSTIC_IMAGE)" --restart=Never --attach=true --rm --command --
@@ -179,7 +178,7 @@ k8s-database-diagnose: k8s-require-env
 
 ## Compare rendered Kustomize/Helm desired state with live Kubernetes resources
 k8s-diff: k8s-require-overlay
-	@$(K8S_KUSTOMIZE_BUILD) \
+	@$(call K8S_KUSTOMIZE_BUILD,$(K8S_ENV),$(K8S_SERVICE)) \
 		| $(K8S_TOOLS_STDIN_ALIAS) kubectl diff \
 			--kubeconfig "$(K8S_KUBECONFIG)" \
 			-f -

--- a/make/k8s-operations.mk
+++ b/make/k8s-operations.mk
@@ -8,16 +8,21 @@ K8S_RESOURCE_NAME ?=
 K8S_CONTAINER ?=
 K8S_IMAGE ?=
 K8S_LOG_TAIL ?= 200
+K8S_LOG_PREVIOUS ?= false
 K8S_ROLLOUT_TIMEOUT ?= 5m
 K8S_ROLLBACK_REVISION ?=
 K8S_AUTO_ROLLBACK ?= true
 K8S_OPERATIONS_NAMESPACE ?= $(if $(filter default,$(K8S_NAMESPACE)),$(K8S_SERVICE),$(K8S_NAMESPACE))
+K8S_OVERLAY_DIR ?= manifests/overlays/$(K8S_ENV)/$(K8S_SERVICE)
 ifndef K8S_BACKUP_TIMESTAMP
 K8S_BACKUP_TIMESTAMP := $(shell date -u +%Y%m%dT%H%M%SZ)
 endif
 K8S_BACKUP_DIR ?= logs/kubernetes/backups/$(K8S_ENV)/$(K8S_SERVICE)
 K8S_BACKUP_FILE ?= $(K8S_BACKUP_DIR)/$(K8S_BACKUP_TIMESTAMP).yaml
 K8S_RECOVERY_FILE ?=
+
+K8S_KUSTOMIZE_BUILD = $(K8S_TOOLS_ALIAS) kustomize build "$(K8S_OVERLAY_DIR)" --enable-helm --load-restrictor=LoadRestrictionsNone
+K8S_LOG_PREVIOUS_FLAG = $(if $(filter true,$(K8S_LOG_PREVIOUS)),--previous=true,)
 
 # Validate that a Kubernetes environment was specified
 k8s-require-env:
@@ -49,6 +54,47 @@ k8s-require-upgrade: k8s-require-env k8s-require-resource
 		exit 2; \
 	fi
 .PHONY: k8s-require-upgrade
+
+# Validate that the selected Kustomize overlay exists
+k8s-require-overlay: k8s-require-env
+	@if [[ ! -f "$(K8S_OVERLAY_DIR)/kustomization.yaml" ]]; then \
+		echo "error: Kubernetes overlay does not exist: $(K8S_OVERLAY_DIR)" >&2; \
+		exit 2; \
+	fi
+.PHONY: k8s-require-overlay
+
+# Show rollout history for the selected workload
+k8s-rollout-history: k8s-require-resource
+	@$(K8S_TOOLS_ALIAS) kubectl rollout history \
+		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)"
+.PHONY: k8s-rollout-history
+
+# Wait for the selected workload rollout to complete
+k8s-rollout-status: k8s-require-resource
+	@$(K8S_TOOLS_ALIAS) kubectl rollout status \
+		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		--timeout="$(K8S_ROLLOUT_TIMEOUT)"
+.PHONY: k8s-rollout-status
+
+# Roll back the selected workload to the previous or explicitly selected revision
+k8s-rollout-undo: k8s-require-resource
+	@if [[ -n "$(strip $(K8S_ROLLBACK_REVISION))" ]]; then \
+		$(K8S_TOOLS_ALIAS) kubectl rollout undo \
+			"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+			--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+			--kubeconfig "$(K8S_KUBECONFIG)" \
+			--to-revision="$(K8S_ROLLBACK_REVISION)"; \
+	else \
+		$(K8S_TOOLS_ALIAS) kubectl rollout undo \
+			"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+			--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+			--kubeconfig "$(K8S_KUBECONFIG)"; \
+	fi
+.PHONY: k8s-rollout-undo
 
 ## Monitor Kubernetes service health, workload state, resource usage, and warning events
 k8s-monitor: k8s-require-resource
@@ -97,10 +143,7 @@ k8s-describe: k8s-require-resource
 		--kubeconfig "$(K8S_KUBECONFIG)"
 
 	@echo "──── Rollout History ─────────────────────────────────────────────────────────────────────"
-	@$(K8S_TOOLS_ALIAS) kubectl rollout history \
-		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
-		--kubeconfig "$(K8S_KUBECONFIG)"
+	@$(MAKE) -s k8s-rollout-history
 .PHONY: k8s-describe
 
 ## Retrieve recent logs from all containers associated with a Kubernetes workload
@@ -111,35 +154,23 @@ k8s-logs: k8s-require-resource
 		--kubeconfig "$(K8S_KUBECONFIG)" \
 		--all-containers=true \
 		--all-pods=true \
-		--prefix=true \
+		--prefix=true $(K8S_LOG_PREVIOUS_FLAG) \
 		--tail="$(K8S_LOG_TAIL)"
 .PHONY: k8s-logs
 
-## Troubleshoot a Kubernetes service using health, events, workload details, rollout history, and logs
-k8s-troubleshoot: k8s-require-resource
-	@$(MAKE) -s k8s-monitor
-	@$(MAKE) -s k8s-describe
-	@echo "──── Recent Logs ─────────────────────────────────────────────────────────────────────────"
-	@$(MAKE) -s k8s-logs || echo "Logs unavailable for the selected workload."
-.PHONY: k8s-troubleshoot
+## Retrieve logs from the previous terminated container instances of a Kubernetes workload
+k8s-logs-previous: k8s-require-resource
+	@$(MAKE) -s k8s-logs K8S_LOG_PREVIOUS=true
+.PHONY: k8s-logs-previous
 
 ## Create a recovery-ready snapshot of the rendered Kubernetes desired state
-k8s-backup: k8s-require-env
+k8s-backup: k8s-require-overlay
 	@set -euo pipefail; \
-	overlay_dir="manifests/overlays/$(K8S_ENV)/$(K8S_SERVICE)"; \
-	if [[ ! -f "$$overlay_dir/kustomization.yaml" ]]; then \
-		echo "error: Kubernetes overlay does not exist: $$overlay_dir" >&2; \
-		exit 2; \
-	fi; \
 	umask 077; \
 	mkdir -p "$(K8S_BACKUP_DIR)"; \
 	tmp_file="$$(mktemp "$(K8S_BACKUP_DIR)/.snapshot.XXXXXX")"; \
 	trap 'rm -f "$$tmp_file"' EXIT; \
-	$(K8S_TOOLS_ALIAS) kustomize build \
-		"$$overlay_dir" \
-		--enable-helm \
-		--load-restrictor=LoadRestrictionsNone \
-		> "$$tmp_file"; \
+	$(K8S_KUSTOMIZE_BUILD) > "$$tmp_file"; \
 	chmod 0600 "$$tmp_file"; \
 	mv "$$tmp_file" "$(K8S_BACKUP_FILE)"; \
 	trap - EXIT; \
@@ -166,21 +197,14 @@ k8s-recover: k8s-require-env
 		-f "$(K8S_RECOVERY_FILE)"
 
 	@if [[ -n "$(strip $(K8S_RESOURCE_NAME))" ]]; then \
-		$(K8S_TOOLS_ALIAS) kubectl rollout status \
-			"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-			--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
-			--kubeconfig "$(K8S_KUBECONFIG)" \
-			--timeout="$(K8S_ROLLOUT_TIMEOUT)"; \
+		$(MAKE) -s k8s-rollout-status; \
 	fi
 .PHONY: k8s-recover
 
 ## Upgrade a Kubernetes workload image with pre-change backup, rollout verification, and automatic rollback
 k8s-upgrade: k8s-require-upgrade k8s-backup
 	@echo "──── Current Rollout History ─────────────────────────────────────────────────────────────"
-	@$(K8S_TOOLS_ALIAS) kubectl rollout history \
-		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
-		--kubeconfig "$(K8S_KUBECONFIG)"
+	@$(MAKE) -s k8s-rollout-history
 
 	@$(MAKE) -s k8s-confirm K8S_STACK_DIR="$(K8S_SERVICE)"
 
@@ -191,23 +215,12 @@ k8s-upgrade: k8s-require-upgrade k8s-backup
 		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 		--kubeconfig "$(K8S_KUBECONFIG)"
 
-	@if ! $(K8S_TOOLS_ALIAS) kubectl rollout status \
-		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
-		--kubeconfig "$(K8S_KUBECONFIG)" \
-		--timeout="$(K8S_ROLLOUT_TIMEOUT)"; then \
+	@if ! $(MAKE) -s k8s-rollout-status; then \
 		echo "Upgrade rollout failed."; \
 		if [[ "$(K8S_AUTO_ROLLBACK)" == "true" ]]; then \
 			echo "Automatic rollback initiated."; \
-			$(K8S_TOOLS_ALIAS) kubectl rollout undo \
-				"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-				--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
-				--kubeconfig "$(K8S_KUBECONFIG)"; \
-			$(K8S_TOOLS_ALIAS) kubectl rollout status \
-				"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-				--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
-				--kubeconfig "$(K8S_KUBECONFIG)" \
-				--timeout="$(K8S_ROLLOUT_TIMEOUT)"; \
+			$(MAKE) -s k8s-rollout-undo; \
+			$(MAKE) -s k8s-rollout-status; \
 		fi; \
 		exit 1; \
 	fi
@@ -218,29 +231,10 @@ k8s-upgrade: k8s-require-upgrade k8s-backup
 ## Roll back a Kubernetes workload to its previous or explicitly selected revision
 k8s-rollback: k8s-require-env k8s-require-resource
 	@echo "──── Rollout History ─────────────────────────────────────────────────────────────────────"
-	@$(K8S_TOOLS_ALIAS) kubectl rollout history \
-		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
-		--kubeconfig "$(K8S_KUBECONFIG)"
+	@$(MAKE) -s k8s-rollout-history
 
 	@$(MAKE) -s k8s-confirm K8S_STACK_DIR="$(K8S_SERVICE)"
 
-	@if [[ -n "$(strip $(K8S_ROLLBACK_REVISION))" ]]; then \
-		$(K8S_TOOLS_ALIAS) kubectl rollout undo \
-			"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-			--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
-			--kubeconfig "$(K8S_KUBECONFIG)" \
-			--to-revision="$(K8S_ROLLBACK_REVISION)"; \
-	else \
-		$(K8S_TOOLS_ALIAS) kubectl rollout undo \
-			"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-			--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
-			--kubeconfig "$(K8S_KUBECONFIG)"; \
-	fi
-
-	@$(K8S_TOOLS_ALIAS) kubectl rollout status \
-		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
-		--kubeconfig "$(K8S_KUBECONFIG)" \
-		--timeout="$(K8S_ROLLOUT_TIMEOUT)"
+	@$(MAKE) -s k8s-rollout-undo
+	@$(MAKE) -s k8s-rollout-status
 .PHONY: k8s-rollback

--- a/make/k8s-operations.mk
+++ b/make/k8s-operations.mk
@@ -40,8 +40,8 @@ k8s-require-resource:
 	fi
 .PHONY: k8s-require-resource
 
-# Validate parameters required for an image upgrade
-k8s-require-upgrade: k8s-require-env k8s-require-resource
+# Validate parameters required for a temporary live image hotfix
+k8s-require-image-hotfix: k8s-require-env k8s-require-resource
 	@if [[ -z "$(strip $(K8S_CONTAINER))" ]]; then \
 		echo "error: K8S_CONTAINER is required" >&2; \
 		exit 2; \
@@ -51,7 +51,7 @@ k8s-require-upgrade: k8s-require-env k8s-require-resource
 		echo "error: K8S_IMAGE is required" >&2; \
 		exit 2; \
 	fi
-.PHONY: k8s-require-upgrade
+.PHONY: k8s-require-image-hotfix
 
 # Validate that the selected Kustomize overlay exists
 k8s-require-overlay: k8s-require-env
@@ -191,14 +191,16 @@ k8s-recover: k8s-require-env
 	fi
 .PHONY: k8s-recover
 
-## Upgrade a Kubernetes workload image with pre-change backup, rollout verification, and automatic rollback
-k8s-upgrade: k8s-require-upgrade k8s-backup
+## Apply a temporary live image hotfix with pre-change backup, rollout verification, and automatic rollback
+k8s-image-hotfix: k8s-require-image-hotfix k8s-backup
+	@echo "WARNING: k8s-image-hotfix changes only the live workload and does not update the declarative overlay."
+	@echo "Update the Kustomize/Helm image configuration before the next k8s-deploy or the hotfix may be reverted."
 	@echo "──── Current Rollout History ─────────────────────────────────────────────────────────────"
 	@$(MAKE) -s k8s-rollout-history
 
 	@$(MAKE) -s k8s-confirm K8S_STACK_DIR="$(K8S_SERVICE)"
 
-	@echo "──── Upgrade ─────────────────────────────────────────────────────────────────────────────"
+	@echo "──── Image Hotfix ────────────────────────────────────────────────────────────────────────"
 	@$(K8S_TOOLS_ALIAS) kubectl set image \
 		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
 		"$(K8S_CONTAINER)=$(K8S_IMAGE)" \
@@ -206,7 +208,7 @@ k8s-upgrade: k8s-require-upgrade k8s-backup
 		--kubeconfig "$(K8S_KUBECONFIG)"
 
 	@if ! $(MAKE) -s k8s-rollout-status; then \
-		echo "Upgrade rollout failed."; \
+		echo "Image hotfix rollout failed."; \
 		if [[ "$(K8S_AUTO_ROLLBACK)" == "true" ]]; then \
 			echo "Automatic rollback initiated."; \
 			$(MAKE) -s k8s-rollout-undo; \
@@ -215,8 +217,8 @@ k8s-upgrade: k8s-require-upgrade k8s-backup
 		exit 1; \
 	fi
 
-	@echo "Upgrade completed successfully."
-.PHONY: k8s-upgrade
+	@echo "Image hotfix completed; reconcile the declarative overlay before the next deployment."
+.PHONY: k8s-image-hotfix
 
 ## Roll back a Kubernetes workload to its previous or explicitly selected revision
 k8s-rollback: k8s-require-env k8s-require-resource

--- a/make/k8s-operations.mk
+++ b/make/k8s-operations.mk
@@ -11,10 +11,22 @@ K8S_LOG_TAIL ?= 200
 K8S_ROLLOUT_TIMEOUT ?= 5m
 K8S_ROLLBACK_REVISION ?=
 K8S_AUTO_ROLLBACK ?= true
-K8S_BACKUP_TIMESTAMP ?= $(shell date -u +%Y%m%dT%H%M%SZ)
-K8S_BACKUP_DIR ?= logs/kubernetes/backups/$(or $(K8S_ENV),local)/$(K8S_SERVICE)
+K8S_OPERATIONS_NAMESPACE ?= $(if $(filter default,$(K8S_NAMESPACE)),$(K8S_SERVICE),$(K8S_NAMESPACE))
+ifndef K8S_BACKUP_TIMESTAMP
+K8S_BACKUP_TIMESTAMP := $(shell date -u +%Y%m%dT%H%M%SZ)
+endif
+K8S_BACKUP_DIR ?= logs/kubernetes/backups/$(K8S_ENV)/$(K8S_SERVICE)
 K8S_BACKUP_FILE ?= $(K8S_BACKUP_DIR)/$(K8S_BACKUP_TIMESTAMP).yaml
 K8S_RECOVERY_FILE ?=
+
+# Validate that a Kubernetes environment was specified
+k8s-require-env:
+	@if [[ -z "$(strip $(K8S_ENV))" ]]; then \
+		echo "error: K8S_ENV is required" >&2; \
+		echo "usage: make <target> K8S_ENV=<dev|stage|prod>" >&2; \
+		exit 2; \
+	fi
+.PHONY: k8s-require-env
 
 # Validate that a workload resource was specified
 k8s-require-resource:
@@ -26,7 +38,7 @@ k8s-require-resource:
 .PHONY: k8s-require-resource
 
 # Validate parameters required for an image upgrade
-k8s-require-upgrade: k8s-require-resource
+k8s-require-upgrade: k8s-require-env k8s-require-resource
 	@if [[ -z "$(strip $(K8S_CONTAINER))" ]]; then \
 		echo "error: K8S_CONTAINER is required" >&2; \
 		exit 2; \
@@ -43,26 +55,26 @@ k8s-monitor: k8s-require-resource
 	@echo "──── Workload ────────────────────────────────────────────────────────────────────────────"
 	@$(K8S_TOOLS_ALIAS) kubectl get \
 		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-		--namespace "$(K8S_NAMESPACE)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 		--kubeconfig "$(K8S_KUBECONFIG)" \
 		-o wide
 
 	@echo "──── Pods, Services & Ingresses ──────────────────────────────────────────────────────────"
 	@$(K8S_TOOLS_ALIAS) kubectl get \
 		pods,services,ingresses \
-		--namespace "$(K8S_NAMESPACE)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 		--kubeconfig "$(K8S_KUBECONFIG)" \
 		-o wide
 
 	@echo "──── Resource Usage ──────────────────────────────────────────────────────────────────────"
 	@$(K8S_TOOLS_ALIAS) kubectl top pods \
-		--namespace "$(K8S_NAMESPACE)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 		--kubeconfig "$(K8S_KUBECONFIG)" \
 		|| echo "Metrics API unavailable; skipping resource usage."
 
 	@echo "──── Warning Events ──────────────────────────────────────────────────────────────────────"
 	@$(K8S_TOOLS_ALIAS) kubectl get events \
-		--namespace "$(K8S_NAMESPACE)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 		--kubeconfig "$(K8S_KUBECONFIG)" \
 		--field-selector type=Warning \
 		--sort-by=.lastTimestamp
@@ -71,7 +83,7 @@ k8s-monitor: k8s-require-resource
 ## Continuously watch Kubernetes pods for service availability and rollout changes
 k8s-watch:
 	@$(K8S_TOOLS_ALIAS) kubectl get pods \
-		--namespace "$(K8S_NAMESPACE)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 		--kubeconfig "$(K8S_KUBECONFIG)" \
 		--watch
 .PHONY: k8s-watch
@@ -81,13 +93,13 @@ k8s-describe: k8s-require-resource
 	@echo "──── Workload Description ────────────────────────────────────────────────────────────────"
 	@$(K8S_TOOLS_ALIAS) kubectl describe \
 		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-		--namespace "$(K8S_NAMESPACE)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 		--kubeconfig "$(K8S_KUBECONFIG)"
 
 	@echo "──── Rollout History ─────────────────────────────────────────────────────────────────────"
 	@$(K8S_TOOLS_ALIAS) kubectl rollout history \
 		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-		--namespace "$(K8S_NAMESPACE)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 		--kubeconfig "$(K8S_KUBECONFIG)"
 .PHONY: k8s-describe
 
@@ -95,7 +107,7 @@ k8s-describe: k8s-require-resource
 k8s-logs: k8s-require-resource
 	@$(K8S_TOOLS_ALIAS) kubectl logs \
 		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-		--namespace "$(K8S_NAMESPACE)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 		--kubeconfig "$(K8S_KUBECONFIG)" \
 		--all-containers=true \
 		--all-pods=true \
@@ -112,28 +124,32 @@ k8s-troubleshoot: k8s-require-resource
 .PHONY: k8s-troubleshoot
 
 ## Create a recovery-ready snapshot of the rendered Kubernetes desired state
-k8s-backup:
-	@if [[ -z "$(strip $(K8S_ENV))" ]]; then \
-		echo "error: K8S_ENV is required" >&2; \
-		echo "usage: make k8s-backup K8S_ENV=<dev|stage|prod> [K8S_SERVICE=dependency-track]" >&2; \
+k8s-backup: k8s-require-env
+	@overlay_dir="manifests/overlays/$(K8S_ENV)/$(K8S_SERVICE)"
+	@if [[ ! -f "$$overlay_dir/kustomization.yaml" ]]; then \
+		echo "error: Kubernetes overlay does not exist: $$overlay_dir" >&2; \
 		exit 2; \
 	fi
 
 	@umask 077
 	@mkdir -p "$(K8S_BACKUP_DIR)"
+	@tmp_file="$$(mktemp "$(K8S_BACKUP_DIR)/.snapshot.XXXXXX")"
+	@trap 'rm -f "$$tmp_file"' EXIT
 
 	@$(K8S_TOOLS_ALIAS) kustomize build \
-		"manifests/overlays/$(K8S_ENV)/$(K8S_SERVICE)" \
+		"$$overlay_dir" \
 		--enable-helm \
 		--load-restrictor=LoadRestrictionsNone \
-		> "$(K8S_BACKUP_FILE)"
+		> "$$tmp_file"
 
-	@chmod 0600 "$(K8S_BACKUP_FILE)"
+	@chmod 0600 "$$tmp_file"
+	@mv "$$tmp_file" "$(K8S_BACKUP_FILE)"
+	@trap - EXIT
 	@echo "Kubernetes recovery snapshot: $(K8S_BACKUP_FILE)"
 .PHONY: k8s-backup
 
 ## Recover Kubernetes resources from a previously rendered recovery snapshot
-k8s-recover:
+k8s-recover: k8s-require-env
 	@if [[ -z "$(strip $(K8S_RECOVERY_FILE))" ]]; then \
 		echo "error: K8S_RECOVERY_FILE is required" >&2; \
 		echo "usage: make k8s-recover K8S_ENV=<env> K8S_RECOVERY_FILE=<file>" >&2; \
@@ -154,7 +170,7 @@ k8s-recover:
 	@if [[ -n "$(strip $(K8S_RESOURCE_NAME))" ]]; then \
 		$(K8S_TOOLS_ALIAS) kubectl rollout status \
 			"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-			--namespace "$(K8S_NAMESPACE)" \
+			--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 			--kubeconfig "$(K8S_KUBECONFIG)" \
 			--timeout="$(K8S_ROLLOUT_TIMEOUT)"; \
 	fi
@@ -165,19 +181,21 @@ k8s-upgrade: k8s-require-upgrade k8s-backup
 	@echo "──── Current Rollout History ─────────────────────────────────────────────────────────────"
 	@$(K8S_TOOLS_ALIAS) kubectl rollout history \
 		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-		--namespace "$(K8S_NAMESPACE)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 		--kubeconfig "$(K8S_KUBECONFIG)"
+
+	@$(MAKE) -s k8s-confirm K8S_STACK_DIR="$(K8S_SERVICE)"
 
 	@echo "──── Upgrade ─────────────────────────────────────────────────────────────────────────────"
 	@$(K8S_TOOLS_ALIAS) kubectl set image \
 		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
 		"$(K8S_CONTAINER)=$(K8S_IMAGE)" \
-		--namespace "$(K8S_NAMESPACE)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 		--kubeconfig "$(K8S_KUBECONFIG)"
 
 	@if ! $(K8S_TOOLS_ALIAS) kubectl rollout status \
 		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-		--namespace "$(K8S_NAMESPACE)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 		--kubeconfig "$(K8S_KUBECONFIG)" \
 		--timeout="$(K8S_ROLLOUT_TIMEOUT)"; then \
 		echo "Upgrade rollout failed."; \
@@ -185,11 +203,11 @@ k8s-upgrade: k8s-require-upgrade k8s-backup
 			echo "Automatic rollback initiated."; \
 			$(K8S_TOOLS_ALIAS) kubectl rollout undo \
 				"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-				--namespace "$(K8S_NAMESPACE)" \
+				--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 				--kubeconfig "$(K8S_KUBECONFIG)"; \
 			$(K8S_TOOLS_ALIAS) kubectl rollout status \
 				"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-				--namespace "$(K8S_NAMESPACE)" \
+				--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 				--kubeconfig "$(K8S_KUBECONFIG)" \
 				--timeout="$(K8S_ROLLOUT_TIMEOUT)"; \
 		fi; \
@@ -200,29 +218,31 @@ k8s-upgrade: k8s-require-upgrade k8s-backup
 .PHONY: k8s-upgrade
 
 ## Roll back a Kubernetes workload to its previous or explicitly selected revision
-k8s-rollback: k8s-require-resource
+k8s-rollback: k8s-require-env k8s-require-resource
 	@echo "──── Rollout History ─────────────────────────────────────────────────────────────────────"
 	@$(K8S_TOOLS_ALIAS) kubectl rollout history \
 		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-		--namespace "$(K8S_NAMESPACE)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 		--kubeconfig "$(K8S_KUBECONFIG)"
+
+	@$(MAKE) -s k8s-confirm K8S_STACK_DIR="$(K8S_SERVICE)"
 
 	@if [[ -n "$(strip $(K8S_ROLLBACK_REVISION))" ]]; then \
 		$(K8S_TOOLS_ALIAS) kubectl rollout undo \
 			"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-			--namespace "$(K8S_NAMESPACE)" \
+			--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 			--kubeconfig "$(K8S_KUBECONFIG)" \
 			--to-revision="$(K8S_ROLLBACK_REVISION)"; \
 	else \
 		$(K8S_TOOLS_ALIAS) kubectl rollout undo \
 			"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-			--namespace "$(K8S_NAMESPACE)" \
+			--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 			--kubeconfig "$(K8S_KUBECONFIG)"; \
 	fi
 
 	@$(K8S_TOOLS_ALIAS) kubectl rollout status \
 		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
-		--namespace "$(K8S_NAMESPACE)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
 		--kubeconfig "$(K8S_KUBECONFIG)" \
 		--timeout="$(K8S_ROLLOUT_TIMEOUT)"
 .PHONY: k8s-rollback

--- a/make/k8s-operations.mk
+++ b/make/k8s-operations.mk
@@ -13,7 +13,6 @@ K8S_ROLLOUT_TIMEOUT ?= 5m
 K8S_ROLLBACK_REVISION ?=
 K8S_AUTO_ROLLBACK ?= true
 K8S_OPERATIONS_NAMESPACE ?= $(if $(filter default,$(K8S_NAMESPACE)),$(K8S_SERVICE),$(K8S_NAMESPACE))
-K8S_OVERLAY_DIR ?= manifests/overlays/$(K8S_ENV)/$(K8S_SERVICE)
 ifndef K8S_BACKUP_TIMESTAMP
 K8S_BACKUP_TIMESTAMP := $(shell date -u +%Y%m%dT%H%M%SZ)
 endif
@@ -21,7 +20,6 @@ K8S_BACKUP_DIR ?= logs/kubernetes/backups/$(K8S_ENV)/$(K8S_SERVICE)
 K8S_BACKUP_FILE ?= $(K8S_BACKUP_DIR)/$(K8S_BACKUP_TIMESTAMP).yaml
 K8S_RECOVERY_FILE ?=
 
-K8S_KUSTOMIZE_BUILD = $(K8S_TOOLS_ALIAS) kustomize build "$(K8S_OVERLAY_DIR)" --enable-helm --load-restrictor=LoadRestrictionsNone
 K8S_LOG_PREVIOUS_FLAG = $(if $(filter true,$(K8S_LOG_PREVIOUS)),--previous=true,)
 
 # Validate that a Kubernetes environment was specified
@@ -57,8 +55,8 @@ k8s-require-upgrade: k8s-require-env k8s-require-resource
 
 # Validate that the selected Kustomize overlay exists
 k8s-require-overlay: k8s-require-env
-	@if [[ ! -f "$(K8S_OVERLAY_DIR)/kustomization.yaml" ]]; then \
-		echo "error: Kubernetes overlay does not exist: $(K8S_OVERLAY_DIR)" >&2; \
+	@if [[ ! -f "$(call K8S_OVERLAY_DIR,$(K8S_ENV),$(K8S_SERVICE))/kustomization.yaml" ]]; then \
+		echo "error: Kubernetes overlay does not exist: $(call K8S_OVERLAY_DIR,$(K8S_ENV),$(K8S_SERVICE))" >&2; \
 		exit 2; \
 	fi
 .PHONY: k8s-require-overlay
@@ -162,7 +160,7 @@ k8s-backup: k8s-require-overlay
 	mkdir -p "$(K8S_BACKUP_DIR)"; \
 	tmp_file="$$(mktemp "$(K8S_BACKUP_DIR)/.snapshot.XXXXXX")"; \
 	trap 'rm -f "$$tmp_file"' EXIT; \
-	$(K8S_KUSTOMIZE_BUILD) > "$$tmp_file"; \
+	$(call K8S_KUSTOMIZE_BUILD,$(K8S_ENV),$(K8S_SERVICE)) > "$$tmp_file"; \
 	chmod 0600 "$$tmp_file"; \
 	mv "$$tmp_file" "$(K8S_BACKUP_FILE)"; \
 	trap - EXIT; \

--- a/make/k8s-operations.mk
+++ b/make/k8s-operations.mk
@@ -125,27 +125,25 @@ k8s-troubleshoot: k8s-require-resource
 
 ## Create a recovery-ready snapshot of the rendered Kubernetes desired state
 k8s-backup: k8s-require-env
-	@overlay_dir="manifests/overlays/$(K8S_ENV)/$(K8S_SERVICE)"
-	@if [[ ! -f "$$overlay_dir/kustomization.yaml" ]]; then \
+	@set -euo pipefail; \
+	overlay_dir="manifests/overlays/$(K8S_ENV)/$(K8S_SERVICE)"; \
+	if [[ ! -f "$$overlay_dir/kustomization.yaml" ]]; then \
 		echo "error: Kubernetes overlay does not exist: $$overlay_dir" >&2; \
 		exit 2; \
-	fi
-
-	@umask 077
-	@mkdir -p "$(K8S_BACKUP_DIR)"
-	@tmp_file="$$(mktemp "$(K8S_BACKUP_DIR)/.snapshot.XXXXXX")"
-	@trap 'rm -f "$$tmp_file"' EXIT
-
-	@$(K8S_TOOLS_ALIAS) kustomize build \
+	fi; \
+	umask 077; \
+	mkdir -p "$(K8S_BACKUP_DIR)"; \
+	tmp_file="$$(mktemp "$(K8S_BACKUP_DIR)/.snapshot.XXXXXX")"; \
+	trap 'rm -f "$$tmp_file"' EXIT; \
+	$(K8S_TOOLS_ALIAS) kustomize build \
 		"$$overlay_dir" \
 		--enable-helm \
 		--load-restrictor=LoadRestrictionsNone \
-		> "$$tmp_file"
-
-	@chmod 0600 "$$tmp_file"
-	@mv "$$tmp_file" "$(K8S_BACKUP_FILE)"
-	@trap - EXIT
-	@echo "Kubernetes recovery snapshot: $(K8S_BACKUP_FILE)"
+		> "$$tmp_file"; \
+	chmod 0600 "$$tmp_file"; \
+	mv "$$tmp_file" "$(K8S_BACKUP_FILE)"; \
+	trap - EXIT; \
+	echo "Kubernetes recovery snapshot: $(K8S_BACKUP_FILE)"
 .PHONY: k8s-backup
 
 ## Recover Kubernetes resources from a previously rendered recovery snapshot

--- a/make/k8s-operations.mk
+++ b/make/k8s-operations.mk
@@ -126,14 +126,6 @@ k8s-monitor: k8s-require-resource
 		--sort-by=.lastTimestamp
 .PHONY: k8s-monitor
 
-## Continuously watch Kubernetes pods for service availability and rollout changes
-k8s-watch:
-	@$(K8S_TOOLS_ALIAS) kubectl get pods \
-		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
-		--kubeconfig "$(K8S_KUBECONFIG)" \
-		--watch
-.PHONY: k8s-watch
-
 ## Describe a Kubernetes workload and display its rollout revision history
 k8s-describe: k8s-require-resource
 	@echo "──── Workload Description ────────────────────────────────────────────────────────────────"

--- a/make/k8s-operations.mk
+++ b/make/k8s-operations.mk
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# ── Kubernetes Service Operations ─────────────────────────────────────────────────────────────────
+
+K8S_SERVICE ?= dependency-track
+K8S_RESOURCE_KIND ?= deployment
+K8S_RESOURCE_NAME ?=
+K8S_CONTAINER ?=
+K8S_IMAGE ?=
+K8S_LOG_TAIL ?= 200
+K8S_ROLLOUT_TIMEOUT ?= 5m
+K8S_ROLLBACK_REVISION ?=
+K8S_AUTO_ROLLBACK ?= true
+K8S_BACKUP_TIMESTAMP ?= $(shell date -u +%Y%m%dT%H%M%SZ)
+K8S_BACKUP_DIR ?= logs/kubernetes/backups/$(or $(K8S_ENV),local)/$(K8S_SERVICE)
+K8S_BACKUP_FILE ?= $(K8S_BACKUP_DIR)/$(K8S_BACKUP_TIMESTAMP).yaml
+K8S_RECOVERY_FILE ?=
+
+# Validate that a workload resource was specified
+k8s-require-resource:
+	@if [[ -z "$(strip $(K8S_RESOURCE_NAME))" ]]; then \
+		echo "error: K8S_RESOURCE_NAME is required" >&2; \
+		echo "usage: make <target> K8S_RESOURCE_NAME=<name> [K8S_RESOURCE_KIND=deployment]" >&2; \
+		exit 2; \
+	fi
+.PHONY: k8s-require-resource
+
+# Validate parameters required for an image upgrade
+k8s-require-upgrade: k8s-require-resource
+	@if [[ -z "$(strip $(K8S_CONTAINER))" ]]; then \
+		echo "error: K8S_CONTAINER is required" >&2; \
+		exit 2; \
+	fi
+
+	@if [[ -z "$(strip $(K8S_IMAGE))" ]]; then \
+		echo "error: K8S_IMAGE is required" >&2; \
+		exit 2; \
+	fi
+.PHONY: k8s-require-upgrade
+
+## Monitor Kubernetes service health, workload state, resource usage, and warning events
+k8s-monitor: k8s-require-resource
+	@echo "──── Workload ────────────────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl get \
+		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+		--namespace "$(K8S_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		-o wide
+
+	@echo "──── Pods, Services & Ingresses ──────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl get \
+		pods,services,ingresses \
+		--namespace "$(K8S_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		-o wide
+
+	@echo "──── Resource Usage ──────────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl top pods \
+		--namespace "$(K8S_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		|| echo "Metrics API unavailable; skipping resource usage."
+
+	@echo "──── Warning Events ──────────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl get events \
+		--namespace "$(K8S_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		--field-selector type=Warning \
+		--sort-by=.lastTimestamp
+.PHONY: k8s-monitor
+
+## Continuously watch Kubernetes pods for service availability and rollout changes
+k8s-watch:
+	@$(K8S_TOOLS_ALIAS) kubectl get pods \
+		--namespace "$(K8S_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		--watch
+.PHONY: k8s-watch
+
+## Describe a Kubernetes workload and display its rollout revision history
+k8s-describe: k8s-require-resource
+	@echo "──── Workload Description ────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl describe \
+		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+		--namespace "$(K8S_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)"
+
+	@echo "──── Rollout History ─────────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl rollout history \
+		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+		--namespace "$(K8S_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)"
+.PHONY: k8s-describe
+
+## Retrieve recent logs from all containers associated with a Kubernetes workload
+k8s-logs: k8s-require-resource
+	@$(K8S_TOOLS_ALIAS) kubectl logs \
+		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+		--namespace "$(K8S_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		--all-containers=true \
+		--all-pods=true \
+		--prefix=true \
+		--tail="$(K8S_LOG_TAIL)"
+.PHONY: k8s-logs
+
+## Troubleshoot a Kubernetes service using health, events, workload details, rollout history, and logs
+k8s-troubleshoot: k8s-require-resource
+	@$(MAKE) -s k8s-monitor
+	@$(MAKE) -s k8s-describe
+	@echo "──── Recent Logs ─────────────────────────────────────────────────────────────────────────"
+	@$(MAKE) -s k8s-logs || echo "Logs unavailable for the selected workload."
+.PHONY: k8s-troubleshoot
+
+## Create a recovery-ready snapshot of the rendered Kubernetes desired state
+k8s-backup:
+	@if [[ -z "$(strip $(K8S_ENV))" ]]; then \
+		echo "error: K8S_ENV is required" >&2; \
+		echo "usage: make k8s-backup K8S_ENV=<dev|stage|prod> [K8S_SERVICE=dependency-track]" >&2; \
+		exit 2; \
+	fi
+
+	@umask 077
+	@mkdir -p "$(K8S_BACKUP_DIR)"
+
+	@$(K8S_TOOLS_ALIAS) kustomize build \
+		"manifests/overlays/$(K8S_ENV)/$(K8S_SERVICE)" \
+		--enable-helm \
+		--load-restrictor=LoadRestrictionsNone \
+		> "$(K8S_BACKUP_FILE)"
+
+	@chmod 0600 "$(K8S_BACKUP_FILE)"
+	@echo "Kubernetes recovery snapshot: $(K8S_BACKUP_FILE)"
+.PHONY: k8s-backup
+
+## Recover Kubernetes resources from a previously rendered recovery snapshot
+k8s-recover:
+	@if [[ -z "$(strip $(K8S_RECOVERY_FILE))" ]]; then \
+		echo "error: K8S_RECOVERY_FILE is required" >&2; \
+		echo "usage: make k8s-recover K8S_ENV=<env> K8S_RECOVERY_FILE=<file>" >&2; \
+		exit 2; \
+	fi
+
+	@if [[ ! -f "$(K8S_RECOVERY_FILE)" ]]; then \
+		echo "error: recovery file does not exist: $(K8S_RECOVERY_FILE)" >&2; \
+		exit 2; \
+	fi
+
+	@$(MAKE) -s k8s-confirm K8S_STACK_DIR="$(K8S_SERVICE)"
+
+	@$(K8S_TOOLS_ALIAS) kubectl apply \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		-f "$(K8S_RECOVERY_FILE)"
+
+	@if [[ -n "$(strip $(K8S_RESOURCE_NAME))" ]]; then \
+		$(K8S_TOOLS_ALIAS) kubectl rollout status \
+			"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+			--namespace "$(K8S_NAMESPACE)" \
+			--kubeconfig "$(K8S_KUBECONFIG)" \
+			--timeout="$(K8S_ROLLOUT_TIMEOUT)"; \
+	fi
+.PHONY: k8s-recover
+
+## Upgrade a Kubernetes workload image with pre-change backup, rollout verification, and automatic rollback
+k8s-upgrade: k8s-require-upgrade k8s-backup
+	@echo "──── Current Rollout History ─────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl rollout history \
+		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+		--namespace "$(K8S_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)"
+
+	@echo "──── Upgrade ─────────────────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl set image \
+		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+		"$(K8S_CONTAINER)=$(K8S_IMAGE)" \
+		--namespace "$(K8S_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)"
+
+	@if ! $(K8S_TOOLS_ALIAS) kubectl rollout status \
+		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+		--namespace "$(K8S_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		--timeout="$(K8S_ROLLOUT_TIMEOUT)"; then \
+		echo "Upgrade rollout failed."; \
+		if [[ "$(K8S_AUTO_ROLLBACK)" == "true" ]]; then \
+			echo "Automatic rollback initiated."; \
+			$(K8S_TOOLS_ALIAS) kubectl rollout undo \
+				"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+				--namespace "$(K8S_NAMESPACE)" \
+				--kubeconfig "$(K8S_KUBECONFIG)"; \
+			$(K8S_TOOLS_ALIAS) kubectl rollout status \
+				"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+				--namespace "$(K8S_NAMESPACE)" \
+				--kubeconfig "$(K8S_KUBECONFIG)" \
+				--timeout="$(K8S_ROLLOUT_TIMEOUT)"; \
+		fi; \
+		exit 1; \
+	fi
+
+	@echo "Upgrade completed successfully."
+.PHONY: k8s-upgrade
+
+## Roll back a Kubernetes workload to its previous or explicitly selected revision
+k8s-rollback: k8s-require-resource
+	@echo "──── Rollout History ─────────────────────────────────────────────────────────────────────"
+	@$(K8S_TOOLS_ALIAS) kubectl rollout history \
+		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+		--namespace "$(K8S_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)"
+
+	@if [[ -n "$(strip $(K8S_ROLLBACK_REVISION))" ]]; then \
+		$(K8S_TOOLS_ALIAS) kubectl rollout undo \
+			"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+			--namespace "$(K8S_NAMESPACE)" \
+			--kubeconfig "$(K8S_KUBECONFIG)" \
+			--to-revision="$(K8S_ROLLBACK_REVISION)"; \
+	else \
+		$(K8S_TOOLS_ALIAS) kubectl rollout undo \
+			"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+			--namespace "$(K8S_NAMESPACE)" \
+			--kubeconfig "$(K8S_KUBECONFIG)"; \
+	fi
+
+	@$(K8S_TOOLS_ALIAS) kubectl rollout status \
+		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+		--namespace "$(K8S_NAMESPACE)" \
+		--kubeconfig "$(K8S_KUBECONFIG)" \
+		--timeout="$(K8S_ROLLOUT_TIMEOUT)"
+.PHONY: k8s-rollback

--- a/make/k8s-tooling.mk
+++ b/make/k8s-tooling.mk
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# ── Kubernetes Operator Tooling ───────────────────────────────────────────────────────────────────
+
+K8S_NETSHOOT_IMAGE ?= nicolaka/netshoot:v0.16
+K8S_STERN_IMAGE ?= ghcr.io/stern/stern:v1.34.0
+K8S_POPEYE_IMAGE ?= derailed/popeye:v0.22.1
+K8S_K9S_IMAGE ?= derailed/k9s:v0.51.0
+
+K8S_CONTAINER_KUBECONFIG ?= /workspace/$(K8S_KUBECONFIG)
+K8S_CLI_CONTAINER_ARGS := --rm --network host --volume "$(CURDIR):/workspace:ro" --workdir /workspace --env KUBECONFIG="$(K8S_CONTAINER_KUBECONFIG)"
+K8S_STERN_ALIAS := docker run $(K8S_CLI_CONTAINER_ARGS) "$(K8S_STERN_IMAGE)"
+K8S_POPEYE_ALIAS := docker run $(K8S_CLI_CONTAINER_ARGS) "$(K8S_POPEYE_IMAGE)"
+K8S_K9S_ALIAS := docker run --interactive --tty $(K8S_CLI_CONTAINER_ARGS) --env TERM=xterm-256color "$(K8S_K9S_IMAGE)"
+
+K8S_DIAGNOSTIC_IMAGE ?= $(K8S_NETSHOOT_IMAGE)
+K8S_STERN_ARGS ?=
+K8S_POPEYE_ARGS ?=
+K8S_K9S_ARGS ?=
+K8S_K9S_READONLY ?= true
+K8S_K9S_READONLY_FLAG = $(if $(filter true,$(K8S_K9S_READONLY)),--readonly,)
+
+## Follow all workload Pod/container logs with the containerized Stern CLI
+k8s-logs-follow: k8s-require-resource
+	@$(K8S_STERN_ALIAS) \
+		"$(K8S_RESOURCE_KIND)/$(K8S_RESOURCE_NAME)" \
+		--namespace "$(K8S_OPERATIONS_NAMESPACE)" \
+		--tail "$(K8S_LOG_TAIL)" \
+		--timestamps=short $(K8S_STERN_ARGS)
+.PHONY: k8s-logs-follow
+
+## Scan live Kubernetes resources for operational issues with the containerized Popeye CLI
+k8s-health-scan:
+	@$(K8S_POPEYE_ALIAS) \
+		-n "$(K8S_OPERATIONS_NAMESPACE)" \
+		--logs none $(K8S_POPEYE_ARGS)
+.PHONY: k8s-health-scan
+
+## Open the containerized K9s operator console in read-only mode by default
+k8s-console:
+	@$(K8S_K9S_ALIAS) \
+		-n "$(K8S_OPERATIONS_NAMESPACE)" \
+		$(K8S_K9S_READONLY_FLAG) $(K8S_K9S_ARGS)
+.PHONY: k8s-console

--- a/make/k8s-tooling.mk
+++ b/make/k8s-tooling.mk
@@ -2,10 +2,10 @@
 
 # ── Kubernetes Operator Tooling ───────────────────────────────────────────────────────────────────
 
-K8S_NETSHOOT_IMAGE ?= nicolaka/netshoot:v0.16
-K8S_STERN_IMAGE ?= ghcr.io/stern/stern:v1.34.0
-K8S_POPEYE_IMAGE ?= derailed/popeye:v0.22.1
-K8S_K9S_IMAGE ?= derailed/k9s:v0.51.0
+K8S_NETSHOOT_IMAGE ?= nicolaka/netshoot:v0.16@sha256:b09d9b21381f47a79b3cbcb30da25266dc17186ea00ae65e99fdc51396f48e70
+K8S_STERN_IMAGE ?= ghcr.io/stern/stern:1.34.0@sha256:e518f9127ac3ee9621355caa37d4829d5bea652a5c59a0ab4b10cafb3b8da579
+K8S_POPEYE_IMAGE ?= derailed/popeye:v0.22.1@sha256:8e68e22c76631054ca1575f2f39eeff5dab1560e57ddfe5ab03bd3e6616eb3e7
+K8S_K9S_IMAGE ?= derailed/k9s:v0.50.18@sha256:988dbcf194c368259ffb8f43472c4abbc3f1a09b68411d1061a6d22e17cd3eb5
 
 K8S_CONTAINER_KUBECONFIG ?= /workspace/$(K8S_KUBECONFIG)
 K8S_CLI_CONTAINER_ARGS := --rm --network host --volume "$(CURDIR):/workspace:ro" --workdir /workspace --env KUBECONFIG="$(K8S_CONTAINER_KUBECONFIG)"

--- a/manifests/base/dependency-track/README.md
+++ b/manifests/base/dependency-track/README.md
@@ -202,19 +202,32 @@ Path-Based DNS Routing ([Ingress Fan-Out](https://kubernetes.io/docs/concepts/se
 
 ### 1.2. Troubleshoot
 
+Generic Kubernetes cluster and workload diagnostics are provided by the root [Troubleshoot](../../../README.md#3-troubleshoot) runbook. The checks below focus on Dependency Track-specific ingress, TLS, and host-network behavior.
+
 #### 1.2.1. Kubernetes Resources
 
-Ensure the resources are created and running correctly.
+Start with the shared read-only Kubernetes diagnostics for the Dependency Track workloads and their Service routing.
 
 ```bash
-kubectl --kubeconfig=config/kubeconfig.yaml -n dependency-track get secret dependency-track-tls
-kubectl --kubeconfig=config/kubeconfig.yaml -n dependency-track get ingress
-kubectl --kubeconfig=config/kubeconfig.yaml -n dependency-track get pods
+# API Server
+make k8s-troubleshoot K8S_RESOURCE_NAME=dependency-track-api-server
+make k8s-network-diagnose K8S_SERVICE_NAME=dependency-track-api-server
+
+# Frontend
+make k8s-troubleshoot K8S_RESOURCE_NAME=dependency-track-frontend
+make k8s-network-diagnose K8S_SERVICE_NAME=dependency-track-frontend
 ```
+
+- TLS Secret
+  > If HTTPS or Ingress TLS termination fails, inspect `secret/dependency-track-tls` and `ingress/dependency-track` using the containerized K9s console in read-only mode.
+
+  ```bash
+  make k8s-console
+  ```
 
 #### 1.2.2. Host Services
 
-Verify the services are accessible via HTTP. The `-k` flag skips TLS verification for self-signed certificates.
+Verify the external client-to-Traefik-to-Service path from the host. The in-cluster `k8s-smoke-test` validates a different network boundary and does not replace these client-side checks. The `-k` flag skips TLS verification for self-signed certificates.
 
 - Path-Based
 

--- a/manifests/overlays/prod/dependency-track/README.md
+++ b/manifests/overlays/prod/dependency-track/README.md
@@ -1,0 +1,16 @@
+# Production overlay notes
+
+This overlay renders Dependency-Track for a production cluster with externally managed PostgreSQL.
+
+## Runtime architecture
+
+- PostgreSQL is external, such as AWS RDS; the in-cluster PostgreSQL base is intentionally omitted.
+- The shared RDS patches remove the development chart-managed database and KEK Secrets.
+- Provision `dependency-track-db` and `dependency-track-kek` in the `dependency-track` namespace before deployment. See `manifests/patches/dependency-track-rds/README.md` for the required keys.
+- The frontend uses same-host relative API routing rather than the development `dependency-track.localhost` URL.
+
+## Ingress
+
+The template Ingress hostname is `dependency-track.example.com`. Replace it with the production DNS name and configure the appropriate production TLS integration before deployment.
+
+Database snapshots, point-in-time recovery, failover, maintenance, and storage lifecycle remain responsibilities of the external PostgreSQL platform rather than these Kubernetes manifests.

--- a/manifests/overlays/prod/dependency-track/kustomization.yaml
+++ b/manifests/overlays/prod/dependency-track/kustomization.yaml
@@ -2,7 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../../base
+  - ../../../base/dependency-track
+  - ../../../base/postgresql
+  - ../../../base/traefik
 
 # patches:
 #   - path: patch.yaml

--- a/manifests/overlays/prod/dependency-track/kustomization.yaml
+++ b/manifests/overlays/prod/dependency-track/kustomization.yaml
@@ -6,6 +6,10 @@ resources:
   - ../../../base/traefik
 
 # PostgreSQL is external in prod (AWS RDS); the in-cluster PostgreSQL base is intentionally omitted.
-
-# patches:
-#   - path: patch.yaml
+# Shared patches remove chart-managed development secrets and require externally managed runtime secrets.
+patches:
+  - path: ../../../patches/dependency-track-rds/delete-chart-db-secret.yaml
+  - path: ../../../patches/dependency-track-rds/delete-chart-kek-secret.yaml
+  - path: ../../../patches/dependency-track-rds/patch-api-server-external-database.yaml
+  - path: ../../../patches/dependency-track-rds/patch-frontend-relative-api.yaml
+  - path: patch.yaml

--- a/manifests/overlays/prod/dependency-track/kustomization.yaml
+++ b/manifests/overlays/prod/dependency-track/kustomization.yaml
@@ -3,8 +3,9 @@ kind: Kustomization
 
 resources:
   - ../../../base/dependency-track
-  - ../../../base/postgresql
   - ../../../base/traefik
+
+# PostgreSQL is external in prod (AWS RDS); the in-cluster PostgreSQL base is intentionally omitted.
 
 # patches:
 #   - path: patch.yaml

--- a/manifests/overlays/prod/dependency-track/patch.yaml
+++ b/manifests/overlays/prod/dependency-track/patch.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dependency-track
+  namespace: dependency-track
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: "dependency-track.example.com"
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: dependency-track-api-server
+                port:
+                  name: web
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dependency-track-frontend
+                port:
+                  name: web

--- a/manifests/overlays/stage/dependency-track/README.md
+++ b/manifests/overlays/stage/dependency-track/README.md
@@ -1,29 +1,30 @@
-Stage overlay notes for AWS EKS
+# Stage overlay notes for AWS EKS
 
-This overlay adapts the base manifests for a remote staging cluster (EKS).
+This overlay adapts the base manifests for a remote staging cluster on EKS.
 
-What this overlay does
-- Patches the Traefik Service to `type: LoadBalancer` so EKS will provision a
-  cloud Load Balancer (NLB/ELB) and expose ports 80/443.
-- Ensures `hostNetwork: false` for Traefik (don't bind to node host network).
+## Runtime architecture
 
-TLS and certificates
-- Do not use the overlay's self-signed `secretGenerator` in staging. Instead
-  use cert-manager or an existing Kubernetes TLS secret backed by ACM or a
-  certificate issued for your staging domain.
+- PostgreSQL is external and supplied by AWS RDS; the in-cluster PostgreSQL base is intentionally omitted.
+- The shared RDS patches remove the development chart-managed database and KEK Secrets.
+- Provision `dependency-track-db` and `dependency-track-kek` in the `dependency-track` namespace before deployment. See `manifests/patches/dependency-track-rds/README.md` for the required keys.
+- The frontend uses same-host relative API routing rather than the development `dependency-track.localhost` URL.
 
-Access
-- After applying the overlay, find the external LB address:
+## Traefik
 
-  kubectl -n traefik get svc traefik
+- The Traefik Service is patched to `type: LoadBalancer` so EKS can provision a cloud load balancer for ports 80/443.
+- `hostNetwork` is disabled for the remote cluster.
+- The Dependency-Track Ingress uses `dependency-track.staging.example.com`; replace this template hostname with the staging DNS name before deployment.
 
-  Use the external IP/DNS returned by the LoadBalancer and point your DNS or
-  /etc/hosts accordingly to access:
+## TLS and certificates
 
-  - dependency-track.staging.example.com
-  - api.dependency-track.staging.example.com
+Do not use the development overlay's self-signed `secretGenerator` in staging. Use cert-manager, an existing Kubernetes TLS Secret, or load-balancer certificate integration suitable for the cluster.
 
-Recommendations
-- Use cert-manager with a ClusterIssuer for ACME or import an ACM certificate
-  into the Load Balancer, then reference the TLS secret in the Ingress.
+## Access
 
+After applying the overlay, inspect the Traefik load-balancer address:
+
+```sh
+kubectl -n traefik get svc traefik
+```
+
+Point staging DNS at the returned external address and configure TLS for the selected hostname.

--- a/manifests/overlays/stage/dependency-track/kustomization.yaml
+++ b/manifests/overlays/stage/dependency-track/kustomization.yaml
@@ -6,8 +6,12 @@ resources:
   - ../../../base/traefik
 
 # PostgreSQL is external in stage (AWS RDS); the in-cluster PostgreSQL base is intentionally omitted.
-
-# Patches to adapt Traefik for a remote (EKS) cluster
+# Shared patches remove chart-managed development secrets and require externally managed runtime secrets.
 patches:
+  - path: ../../../patches/dependency-track-rds/delete-chart-db-secret.yaml
+  - path: ../../../patches/dependency-track-rds/delete-chart-kek-secret.yaml
+  - path: ../../../patches/dependency-track-rds/patch-api-server-external-database.yaml
+  - path: ../../../patches/dependency-track-rds/patch-frontend-relative-api.yaml
+  - path: patch-dependency-track-ingress.yaml
   - path: patch-traefik-service-loadbalancer.yaml
   - path: patch-traefik-deployment-hostnetwork-false.yaml

--- a/manifests/overlays/stage/dependency-track/kustomization.yaml
+++ b/manifests/overlays/stage/dependency-track/kustomization.yaml
@@ -3,8 +3,9 @@ kind: Kustomization
 
 resources:
   - ../../../base/dependency-track
-  - ../../../base/postgresql
   - ../../../base/traefik
+
+# PostgreSQL is external in stage (AWS RDS); the in-cluster PostgreSQL base is intentionally omitted.
 
 # Patches to adapt Traefik for a remote (EKS) cluster
 patches:

--- a/manifests/overlays/stage/dependency-track/kustomization.yaml
+++ b/manifests/overlays/stage/dependency-track/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../../base
+  - ../../../base/dependency-track
+  - ../../../base/postgresql
+  - ../../../base/traefik
 
 # Patches to adapt Traefik for a remote (EKS) cluster
 patches:
-	- path: patch-traefik-service-loadbalancer.yaml
-	- path: patch-traefik-deployment-hostnetwork-false.yaml
+  - path: patch-traefik-service-loadbalancer.yaml
+  - path: patch-traefik-deployment-hostnetwork-false.yaml

--- a/manifests/overlays/stage/dependency-track/patch-dependency-track-ingress.yaml
+++ b/manifests/overlays/stage/dependency-track/patch-dependency-track-ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dependency-track
+  namespace: dependency-track
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: "dependency-track.staging.example.com"
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: dependency-track-api-server
+                port:
+                  name: web
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dependency-track-frontend
+                port:
+                  name: web

--- a/manifests/patches/dependency-track-rds/README.md
+++ b/manifests/patches/dependency-track-rds/README.md
@@ -1,0 +1,16 @@
+# Dependency-Track external PostgreSQL runtime
+
+These patches adapt the shared Dependency-Track Helm rendering for non-development environments where PostgreSQL is supplied externally, such as AWS RDS.
+
+The final manifests intentionally remove the chart-managed `dependency-track-db` and `dependency-track-kek` Secrets. Provision both Secrets in the `dependency-track` namespace before deployment:
+
+- `dependency-track-db`
+  - `jdbcUrl`: complete JDBC URL for the external PostgreSQL database, for example `jdbc:postgresql://<rds-endpoint>:5432/dtrack?sslmode=require`
+  - `username`: database username
+  - `password`: database password
+- `dependency-track-kek`
+  - `kek`: base64-encoded 32-byte Dependency-Track database KEK
+
+The API server reads `DT_DATASOURCE_URL` from the `jdbcUrl` Secret key, while the chart's existing secret volumes continue to mount the database credentials and KEK. The frontend API base URL is cleared so browser requests use the same host as the rendered Ingress.
+
+The external Secrets are operational prerequisites and must be managed outside this repository, for example through External Secrets Operator, Sealed Secrets, SOPS-based deployment automation, or another cluster secret-management mechanism.

--- a/manifests/patches/dependency-track-rds/README.md
+++ b/manifests/patches/dependency-track-rds/README.md
@@ -1,16 +1,75 @@
-# Dependency-Track external PostgreSQL runtime
+# Dependency-Track RDS patches
 
-These patches adapt the shared Dependency-Track Helm rendering for non-development environments where PostgreSQL is supplied externally, such as AWS RDS.
+These shared patches adapt the base Dependency-Track manifests for non-development environments where PostgreSQL is externally managed, such as AWS RDS.
 
-The final manifests intentionally remove the chart-managed `dependency-track-db` and `dependency-track-kek` Secrets. Provision both Secrets in the `dependency-track` namespace before deployment:
+## Runtime architecture
+
+- PostgreSQL runs outside the Kubernetes manifests; the in-cluster PostgreSQL base is not part of the stage or production runtime.
+- The chart-managed `dependency-track-db` and `dependency-track-kek` Secrets are removed from the final rendered manifests.
+- The API server reads `DT_DATASOURCE_URL` from the externally managed `dependency-track-db` Secret.
+- Existing chart secret mounts continue to provide the database username, password, and database KEK from externally managed Secrets with the same names and keys.
+- The frontend API base URL is cleared so browser requests use same-host relative routing through the rendered Ingress.
+
+## Secret contract
+
+Provision the required Secrets in the `dependency-track` namespace before deploying an overlay that consumes these patches.
 
 - `dependency-track-db`
   - `jdbcUrl`: complete JDBC URL for the external PostgreSQL database, for example `jdbc:postgresql://<rds-endpoint>:5432/dtrack?sslmode=require`
   - `username`: database username
   - `password`: database password
 - `dependency-track-kek`
-  - `kek`: base64-encoded 32-byte Dependency-Track database KEK
+  - `kek`: Dependency-Track database KEK value; the application value is a Base64-encoded 32-byte key
 
-The API server reads `DT_DATASOURCE_URL` from the `jdbcUrl` Secret key, while the chart's existing secret volumes continue to mount the database credentials and KEK. The frontend API base URL is cleared so browser requests use the same host as the rendered Ingress.
+Use an external secret-management mechanism such as External Secrets Operator, Sealed Secrets, SOPS-based deployment automation, or another platform-appropriate secret store. Do not commit environment credentials or KEK material to this repository.
 
-The external Secrets are operational prerequisites and must be managed outside this repository, for example through External Secrets Operator, Sealed Secrets, SOPS-based deployment automation, or another cluster secret-management mechanism.
+The following manifest shows the required key structure only:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dependency-track-db
+  namespace: dependency-track
+type: Opaque
+stringData:
+  jdbcUrl: "jdbc:postgresql://<rds-endpoint>:5432/dtrack?sslmode=require"
+  username: "<username>"
+  password: "<password>"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dependency-track-kek
+  namespace: dependency-track
+type: Opaque
+stringData:
+  kek: "<base64-encoded-32-byte-kek>"
+```
+
+> [!NOTE]
+> `stringData` accepts the Dependency-Track KEK application value directly. If a Secret is authored with Kubernetes `data` instead, each value must additionally be Base64-encoded for Kubernetes Secret serialization.
+
+## Patch behavior
+
+- `delete-chart-db-secret.yaml`
+  > Removes the development chart-managed `dependency-track-db` Secret from the rendered manifests.
+
+- `delete-chart-kek-secret.yaml`
+  > Removes the development chart-managed `dependency-track-kek` Secret from the rendered manifests.
+
+- `patch-api-server-external-database.yaml`
+  > Replaces `DT_DATASOURCE_URL` with a reference to `dependency-track-db.jdbcUrl` while preserving the chart's existing database credential mounts.
+
+- `patch-frontend-relative-api.yaml`
+  > Clears `API_BASE_URL` so the frontend uses same-host relative API routing instead of the development `dependency-track.localhost` URL.
+
+## Operations
+
+These patches configure the Kubernetes application boundary only. Database snapshots, point-in-time recovery, failover, maintenance, storage lifecycle, parameter management, and other RDS operations remain responsibilities of the external PostgreSQL platform.
+
+Use the root [Troubleshoot](../../../README.md#3-troubleshoot) runbook to validate the Kubernetes workload and the application-to-database DNS/TCP path. For stage or production, provide the external database endpoint explicitly:
+
+```bash
+make k8s-database-diagnose K8S_ENV=<stage|prod> K8S_DATABASE_HOST=<rds-endpoint>
+```

--- a/manifests/patches/dependency-track-rds/delete-chart-db-secret.yaml
+++ b/manifests/patches/dependency-track-rds/delete-chart-db-secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dependency-track-db
+  namespace: dependency-track
+$patch: delete

--- a/manifests/patches/dependency-track-rds/delete-chart-kek-secret.yaml
+++ b/manifests/patches/dependency-track-rds/delete-chart-kek-secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dependency-track-kek
+  namespace: dependency-track
+$patch: delete

--- a/manifests/patches/dependency-track-rds/patch-api-server-external-database.yaml
+++ b/manifests/patches/dependency-track-rds/patch-api-server-external-database.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dependency-track-api-server
+  namespace: dependency-track
+spec:
+  template:
+    spec:
+      containers:
+        - name: api-server
+          env:
+            - name: DT_DATASOURCE_URL
+              $patch: replace
+              valueFrom:
+                secretKeyRef:
+                  name: dependency-track-db
+                  key: jdbcUrl

--- a/manifests/patches/dependency-track-rds/patch-frontend-relative-api.yaml
+++ b/manifests/patches/dependency-track-rds/patch-frontend-relative-api.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dependency-track-frontend
+  namespace: dependency-track
+spec:
+  template:
+    spec:
+      containers:
+        - name: frontend
+          env:
+            - name: API_BASE_URL
+              $patch: replace
+              value: ""


### PR DESCRIPTION
## Summary

Adds operational Make tasks for troubleshooting and resilience of Kubernetes-based services while keeping the project `Makefile` as the canonical base.

The PR uses a `GNUmakefile` entrypoint to load three focused extensions:

- `make/k8s-operations.mk` for deterministic monitoring, backup, recovery, live image hotfixes, rollback, and shared workload-operation primitives
- `make/k8s-tooling.mk` for digest-pinned, containerized operator CLIs and diagnostic images
- `make/k8s-diagnostics.mk` for cluster, selected Pod/Node, network, RBAC, database-connectivity, drift, smoke-test, and ephemeral-debug workflows

## Changes

### Shared Kubernetes execution

- define one Kustomize+Helm rendering primitive used by deploy, destroy, render, backup, and diff workflows
- keep Kubernetes tooling containerized end-to-end; deploy/destroy pipe rendered manifests into an stdin-attached kubectl tools container instead of host `kubectl`
- remove the legacy `k8s-observability*` resource-listing targets in favor of K9s/Popeye
- remove `k8s-watch`; K9s covers interactive resource watching and Stern covers live workload logs

### Service operations

- add `k8s-monitor` for deterministic workload state, service resources, Pod metrics, and warning events
- add `k8s-describe` and shared current/previous workload log handling
- add `k8s-backup` to render an atomic, timestamped recovery snapshot under the ignored `logs/` tree
- add `k8s-recover` with environment validation and confirmation
- add `k8s-image-hotfix` for explicitly temporary live image overrides with pre-change backup, confirmation, rollout verification, and optional automatic rollback; the command warns that declarative configuration must be reconciled before the next deployment
- add `k8s-rollback` with confirmation and previous/explicit revision support
- centralize rollout history, status, and undo helpers

### Containerized operator tooling

- use Netshoot `v0.16` pinned by digest for temporary probes and ephemeral debug
- add `k8s-logs-follow` backed by Stern `1.34.0`, pinned by digest
- add `k8s-health-scan` backed by Popeye `v0.22.1`, pinned by digest
- add `k8s-console` backed by K9s `v0.50.18`, pinned by digest and read-only by default
- mount the repository read-only into host-side CLI containers and provide the repository kubeconfig through `KUBECONFIG`
- require no Stern, Popeye, K9s, Netshoot, or Krew host binaries

### Troubleshooting diagnostics

- add `k8s-preflight` for API/control-plane connectivity and node visibility
- make `k8s-pod-diagnose` an explicit selected-Pod drill-down requiring `K8S_POD`
- make `k8s-node-diagnose` an explicit selected-Node drill-down requiring `K8S_NODE`
- add `k8s-network-diagnose` for Services, EndpointSlices, Ingresses, and NetworkPolicies
- add `k8s-auth-diagnose` for effective RBAC permissions
- add `k8s-storage-diagnose` for dev-only Kubernetes PostgreSQL storage
- add `k8s-database-diagnose`; dev checks in-cluster PostgreSQL while stage/prod test AWS RDS DNS/TCP connectivity
- add `k8s-diff` against the shared rendered desired state
- add `k8s-smoke-test` using Netshoot `curl`
- add `k8s-debug` using Netshoot by default
- define `k8s-troubleshoot` once and combine deterministic checks with Popeye health scanning without broad Pod-diagnose duplication

### Environment architecture

- keep the in-cluster PostgreSQL base and development credentials in `dev`
- omit the Kubernetes PostgreSQL base from `stage` and `prod`, where PostgreSQL is external such as AWS RDS
- remove chart-managed development DB/KEK Secrets from stage/prod final manifests and require externally managed `dependency-track-db` and `dependency-track-kek` Secrets
- source the stage/prod JDBC URL from the external DB Secret and clear the development frontend API URL in favor of same-host relative routing
- provide environment-specific Ingress host templates and document the external secret contract
- keep RDS administration, snapshots, PITR, failover, and storage lifecycle outside the Kubernetes Make tasks; Kubernetes diagnostics cover the application-to-RDS connectivity boundary

## Rationale

Make remains the deterministic project/runbook API while containerized CLIs cover interactive or generalized inspection:

- K9s: interactive resource console
- Stern: live multi-Pod logs
- Popeye: namespace health/lint scanning
- Netshoot: network/database/application probes and ephemeral debug

This removes redundant custom wrappers without replacing automation-oriented tasks with interactive tooling.

`k8s-backup` remains a Kubernetes desired-state snapshot, not a database backup. Live image hotfixes are intentionally distinguished from declarative upgrades so a subsequent normal deployment cannot silently be mistaken for preserving an imperative override. Velero and Argo Rollouts remain outside this PR because they require corresponding in-cluster platform components; Goldpinger remains an optional continuously running workload rather than a CLI.

## Validation

- verify the canonical `Makefile` diff is scoped to shared Kubernetes rendering/containerized stdin and removal of legacy observability targets
- verify deploy, destroy, render, backup, and diff use one shared Kustomize+Helm rendering primitive
- verify Pod/Node diagnostics require explicit resources and are not part of aggregate troubleshooting
- verify stage/prod renders use the external-RDS patch set and omit chart-managed development DB/KEK Secrets
- Kind CI now triggers on `GNUmakefile` and `make/**` changes, exercises Make-driven backup rendering for stage and prod, and retains the existing certificate-aware Kind deployment test for dev
- Conftest, Regal, Semgrep, Trivy, and Kind run on the final head
