### PR TITLE
chore: group GitHub Actions dependencies

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -66,7 +66,8 @@
         "!kubernetes",
         "!kustomize",
         "!helm-values",
-        "!helmv3"
+        "!helmv3",
+        "!github-actions"
       ],
       "matchDatasources": [
         "!docker"
@@ -84,7 +85,8 @@
         "!kubernetes",
         "!kustomize",
         "!helm-values",
-        "!helmv3"
+        "!helmv3",
+        "!github-actions"
       ],
       "matchDatasources": [
         "!docker"
@@ -102,7 +104,8 @@
         "!kubernetes",
         "!kustomize",
         "!helm-values",
-        "!helmv3"
+        "!helmv3",
+        "!github-actions"
       ],
       "matchDatasources": [
         "!docker"
@@ -236,6 +239,23 @@
       "groupSlug": "kind-container-images",
       "semanticCommits": "enabled",
       "semanticCommitType": "fix",
+      "semanticCommitScope": "deps",
+      "automerge": false
+    },
+    {
+      "description": "Group non-container GitHub Actions dependency updates.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchDepTypes": [
+        "action",
+        "uses-with",
+        "github-runner"
+      ],
+      "groupName": "github actions dependencies",
+      "groupSlug": "github-actions-dependencies",
+      "semanticCommits": "enabled",
+      "semanticCommitType": "ci",
       "semanticCommitScope": "deps",
       "automerge": false
     },


### PR DESCRIPTION
## Summary

Separate normal GitHub Actions dependencies from the generic major/minor/patch Renovate groups while preserving the existing Docker-backed GitHub Actions image policy.

## Changes

- exclude the `github-actions` manager from the generic major, minor, and patch package rules
- add a dedicated `github actions dependencies` group for non-container GitHub Actions dependencies with depTypes:
  - `action`
  - `uses-with`
  - `github-runner`
- retain the existing `docker`, `container`, and `service` rules for GitHub Actions container images, including digest pinning and automerge
- use `ci(deps)` semantic commits for the non-container GitHub Actions group and keep automerge disabled

## Rationale

The previous configuration only specialized Docker-backed dependencies from the `github-actions` manager. Repository action references such as `uses: sentenz/actions/renovate@<sha>` have depType `action`, so they did not match the container-image rule and instead fell through to the generic patch group.

This was visible in Renovate run `31423394645`, where the `sentenz/actions` update was created on `renovate/patch-versions` rather than a GitHub Actions-specific branch.

The revised rules partition GitHub Actions dependencies by depType: normal Actions/runtime/runner dependencies are grouped together, while Docker-backed dependencies continue using the existing image-specific rules.

## Validation

- branch is based on current `main`
- only `renovate.jsonc` is changed
- resulting JSON parses successfully
- verified against the current Renovate GitHub Actions manager documentation that the manager exposes `action`, `uses-with`, `github-runner`, `docker`, `container`, and `service` depTypes
- verified rule partitioning so `github-actions` dependencies no longer fall into generic major/minor/patch groups

## Expected behavior

A future update such as `sentenz/actions` should use the `github-actions-dependencies` group instead of `patch-versions`, while Docker images referenced by GitHub Actions continue to use `github-actions-container-images`.