### PR TITLE
feat(k8s): simplify PostgreSQL dev tenancy

### DIFF
--- a/apps/dependency-track/base/namespace.yaml
+++ b/apps/dependency-track/base/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: dependency-track
+  labels:
+    platform.sentenz.io/postgresql-client: "true"

--- a/apps/dependency-track/overlays/dev/values.yaml
+++ b/apps/dependency-track/overlays/dev/values.yaml
@@ -1,8 +1,10 @@
 ---
 database:
   jdbcUrl: "jdbc:postgresql://postgresql.postgresql.svc.cluster.local:5432/dtrack"
-  username: "dtrack"
-  password: "dtrack"
+  existingSecret:
+    name: dependency-track-database
+    usernameKey: username
+    passwordKey: password
 
 # Development-only fixture KEK. Persistent environments use an externally managed Secret.
 secretManagement:

--- a/clusters/dev/dependency-track-database.fixture
+++ b/clusters/dev/dependency-track-database.fixture
@@ -1,0 +1,2 @@
+username=dtrack
+password=dtrack

--- a/clusters/dev/kustomization.yaml
+++ b/clusters/dev/kustomization.yaml
@@ -8,6 +8,14 @@ resources:
   - ../../apps/dependency-track/overlays/dev
 
 secretGenerator:
+  - name: postgresql-tenant-dependency-track
+    namespace: postgresql
+    envs:
+      - dependency-track-database.fixture
+  - name: dependency-track-database
+    namespace: dependency-track
+    envs:
+      - dependency-track-database.fixture
   - name: dependency-track-tls
     namespace: dependency-track
     type: kubernetes.io/tls

--- a/platform/services/postgresql/README.md
+++ b/platform/services/postgresql/README.md
@@ -2,6 +2,24 @@
 
 PostgreSQL is modeled as a platform-managed runtime service for the example stack and therefore lives under `platform/services/`.
 
-The base owns the namespace. Each environment overlay owns its Helm release and values. Development generates a disposable `postgresql-auth` Secret; stage and production expect that Secret to be supplied externally in the `postgresql` namespace with keys `postgres-password` and `password`.
+The base owns the namespace. Each environment overlay owns its Helm release and values. Development uses disposable cluster-local fixture credentials; stage and production expect credentials to be supplied externally.
 
-In a product-specific repository where a PostgreSQL instance is exclusively owned by one application and shares its lifecycle, colocating that database deployment with the application can be more appropriate. This template keeps PostgreSQL under `platform/services/` to demonstrate the platform-service boundary requested by the repository architecture.
+## Development tenancy
+
+Development keeps one shared PostgreSQL instance and gives each application tenant its own database, login role, and namespace-local Secret.
+
+Dependency-Track is the first tenant:
+
+| Application namespace | Database | Login role | Application Secret |
+| --- | --- | --- | --- |
+| `dependency-track` | `dtrack` | `dtrack` | `dependency-track-database` |
+
+The dev cluster generates the PostgreSQL-side and application-side Secrets from the same fixture file. Dependency-Track consumes only its namespace-local Secret.
+
+The Bitnami chart's native `primary.initdb.scripts` creates the tenant role/database on first PostgreSQL initialization. Because the Kind environment is disposable, tenant changes should recreate the PostgreSQL data or the development cluster. Do not use this first-boot mechanism for persistent environments.
+
+The chart's native NetworkPolicy is configured with `allowExternal: false`; only namespaces labeled `platform.sentenz.io/postgresql-client: "true"` may connect to PostgreSQL. Application roles must not receive `SUPERUSER`, `CREATEDB`, `CREATEROLE`, `REPLICATION`, or `BYPASSRLS`.
+
+To add another development tenant, add a fixture, generate one Secret in the PostgreSQL namespace and one in the application namespace, extend the init script, and label the application namespace as a PostgreSQL client. No per-tenant Job or NetworkPolicy manifest is required.
+
+Stage and production keep externally managed Secrets. When persistent environments require independent backup/restore, high availability, or stronger isolation, prefer dedicated PostgreSQL clusters or a PostgreSQL operator rather than extending the dev bootstrap pattern.

--- a/platform/services/postgresql/overlays/dev/values.yaml
+++ b/platform/services/postgresql/overlays/dev/values.yaml
@@ -2,17 +2,42 @@
 global:
   postgresql:
     auth:
-      username: dtrack
-      database: dtrack
       existingSecret: postgresql-auth
       secretKeys:
         adminPasswordKey: postgres-password
-        userPasswordKey: password
 
 primary:
   resourcesPreset: small
   service:
     type: ClusterIP
+
+  # Kind dev is disposable: bootstrap tenant databases only on first initialization.
+  extraEnvVarsSecret: postgresql-tenant-dependency-track
+  initdb:
+    scripts:
+      10-dependency-track.sh: |
+        #!/bin/sh
+        set -eu
+
+        psql --username postgres --dbname postgres --set=ON_ERROR_STOP=1 \
+          --set=tenant_password="${password}" <<'SQL'
+        CREATE ROLE dtrack
+          LOGIN
+          PASSWORD :'tenant_password'
+          NOSUPERUSER
+          NOCREATEDB
+          NOCREATEROLE
+          NOREPLICATION
+          CONNECTION LIMIT 20;
+        CREATE DATABASE dtrack OWNER dtrack;
+        REVOKE ALL ON DATABASE dtrack FROM PUBLIC;
+        SQL
+
+  networkPolicy:
+    enabled: true
+    allowExternal: false
+    ingressNSMatchLabels:
+      platform.sentenz.io/postgresql-client: "true"
 
 tls:
   enabled: false


### PR DESCRIPTION
## Summary

Simplify development PostgreSQL tenancy while preserving the repository's platform/application/cluster ownership model.

- keep one shared PostgreSQL instance under `platform/services/postgresql`
- give Dependency-Track its own PostgreSQL database/login role and namespace-local Secret
- remove database credentials from Dependency-Track Helm values
- generate PostgreSQL-side and application-side tenant Secrets from one disposable dev fixture
- use the Bitnami PostgreSQL chart's native init scripts for first-boot tenant provisioning
- use the chart's native NetworkPolicy instead of standalone Kubernetes policy manifests

## Simplification

This revision removes the previously added:

- tenant provisioning `Job`
- standalone PostgreSQL `NetworkPolicy` file
- development namespace patch file

The PR is now one commit with six changed files. The only new file is `clusters/dev/dependency-track-database.fixture`; no new standalone Kubernetes manifest files are introduced.

## Development model

The dev-only model remains:

`shared PostgreSQL -> database per tenant -> login role per tenant -> namespace-local application Secret`

Dependency-Track is tenant #1 (`dtrack`). The Bitnami chart's `primary.initdb.scripts` creates its database and restricted login role when the disposable PostgreSQL data directory is first initialized.

Because this mechanism is intentionally first-boot-only, tenant changes in Kind require recreating PostgreSQL data/the dev cluster. Persistent environments should use a PostgreSQL operator, managed service, or another reconciled provisioning mechanism instead.

## Kubernetes best-practice alignment

- application credentials are consumed through namespace-local Secrets rather than Helm values
- the application namespace explicitly identifies itself as a PostgreSQL client
- the Bitnami chart's native NetworkPolicy is configured with `allowExternal: false` and admits only labeled client namespaces
- PostgreSQL application roles are created without `SUPERUSER`, `CREATEDB`, `CREATEROLE`, or `REPLICATION`, with a connection limit and `PUBLIC` database privileges revoked

Stage and production remain unchanged and continue to rely on externally managed Secrets.

## Validation

- branch rewritten to one commit based directly on the PR base
- final diff: six changed files; one new non-Kubernetes fixture file
- all modified YAML parsed successfully
- verified the vendored Bitnami chart supports `primary.initdb.scripts`, `primary.extraEnvVarsSecret`, and namespace-label NetworkPolicy matching
- repository CI is re-triggered on the simplified head

## Follow-up

When persistent environments need independent backup/restore, high availability, per-tenant extensions/versions, or stronger resource isolation, prefer dedicated PostgreSQL clusters or a PostgreSQL operator rather than extending the disposable dev bootstrap pattern.